### PR TITLE
Update README and Claude documentation files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,18 +29,28 @@ npm run ts            # TypeScript型チェック
 
 ## アーキテクチャ
 
-### フロントエンド (Next.js 15 + React 19)
+### フロントエンド (Next.js 16 + React 19)
 - `app/page.tsx`: メインUI（GFFアップロード、トランスクリプト選択、SVGプレビュー）
 - `app/utils/gff.ts`: GFF3パーサー（gff-nostreamを使用）、mRNA抽出、GeneStructureInfo生成
 - `app/components/SvgViewer.tsx`: react-svg-pan-zoomによるSVG表示
+- `app/components/Layout.tsx`: 共通レイアウト
+- `app/api/`: Next.js APIルート
+  - `list-gffs/route.ts`: GFFファイル一覧取得
+  - `upload-gff/route.ts`: GFFファイルアップロード
 - UIコンポーネント: Mantine v8
 
 ### バックエンド (FastAPI)
-- `api/index.py`: REST APIエンドポイント、SVG生成ロジック
+- `api/index.py`: REST APIエンドポイント
   - `POST /api/py/generate-gene-structure-svg`: GeneStructureInfoからSVG生成
-  - クラス: `GeneFeature`（個別feature）、`GeneStructure`（遺伝子全体）
-  - 機能: イントロン自動追加、プロテインドメイン座標変換（アミノ酸→ゲノム）、削除領域処理
-- `api/original.py`: CLIツール
+- `api/models.py`: データモデル
+  - `GeneFeature`: 個別feature（exon、CDS、UTR等）
+  - `GeneStructure`: 遺伝子全体の構造
+  - `GeneStructureRequest`: APIリクエストスキーマ
+  - 機能: イントロン自動追加、プロテインドメイン座標変換、削除領域処理
+- `api/drawer.py`: SVG描画ロジック
+  - `draw_gene_structure()`: メイン描画関数
+  - 色設定、アウトライン設定、マージン設定
+- `api/parser.py`: パーサー
 
 ### API通信
 - Next.js rewrites設定により `/api/py/*` をFastAPIにプロキシ
@@ -57,3 +67,17 @@ npm run ts            # TypeScript型チェック
 - Python: 3.12+（venv使用）
 - フォーマッター: Biome（インデント: スペース2、クォート: ダブル）
 - APIドキュメント: http://127.0.0.1:8000/api/py/docs
+
+## 主要な依存関係
+
+### フロントエンド
+- Mantine v8（UI）
+- react-svg-pan-zoom（SVGビューアー）
+- gff-nostream（GFF3パーサー）
+- swr（データフェッチ）
+- fuse.js（検索）
+
+### バックエンド
+- FastAPI
+- svgwrite（SVG生成）
+- Pydantic（バリデーション）

--- a/README.md
+++ b/README.md
@@ -68,29 +68,34 @@ API ドキュメントは [http://127.0.0.1:8000/api/py/docs](http://127.0.0.1:8
 FastAPIサーバーを起動後、以下のようにAPIを使用できます：
 
 ```bash
-curl -X POST "http://127.0.0.1:8000/api/py/draw-gene" \
+curl -X POST "http://127.0.0.1:8000/api/py/generate-gene-structure-svg" \
   -H "Content-Type: application/json" \
   -d '{
-    "transcript_id": "Os06t0160700-01",
-    "gff_file_path": "./geneSTRUCTURE_v2/gff3/IRGSP-1.0_representative/transcripts.gff",
-    "deletion_regions": [],
-    "domains": [],
-    "protein_domain_start": 1,
-    "protein_domain_end": 120,
-    "protein_domain_name": "domain1"
+    "gene_structure": {
+      "transcript_id": "Os06t0160700-01",
+      "seq_id": "chr06",
+      "strand": "+",
+      "exons": [{"start": 100, "end": 200}],
+      "cds": [{"start": 120, "end": 180}],
+      "five_prime_utrs": [],
+      "three_prime_utrs": []
+    }
   }' \
   -o output.svg
 ```
 
 #### APIパラメータ
 
-- `transcript_id` (required): トランスクリプトID
-- `gff_file_path` (optional): GFF3ファイルのパス（デフォルト: `./gff3/IRGSP-1.0_representative/transcripts.gff`）
-- `deletion_regions` (optional): 削除領域のリスト `[[start, end], ...]`
+- `gene_structure` (required): 遺伝子構造情報オブジェクト
+  - `transcript_id`: トランスクリプトID
+  - `seq_id`: シーケンスID
+  - `strand`: ストランド方向（`+` または `-`）
+  - `exons`: エクソンのリスト `[{"start": number, "end": number}, ...]`
+  - `cds`: CDSのリスト `[{"start": number, "end": number}, ...]`
+  - `five_prime_utrs`: 5' UTRのリスト
+  - `three_prime_utrs`: 3' UTRのリスト
 - `domains` (optional): ドメイン領域のリスト `[{"start": 200, "end": 500, "name": "Kinase", "color": "red"}, ...]`
-- `protein_domain_start` (optional): プロテインドメインの開始位置（アミノ酸座標）
-- `protein_domain_end` (optional): プロテインドメインの終了位置（アミノ酸座標）
-- `protein_domain_name` (optional): プロテインドメインの名前
+- `deletion_regions` (optional): 削除領域のリスト `[[start, end], ...]`
 
 ### CLI ツール
 
@@ -121,13 +126,23 @@ domains = [
 .
 ├── app/                      # フロントエンド (Next.js)
 │   ├── components/          # 共通コンポーネント
+│   │   ├── Layout.tsx       # レイアウトコンポーネント
+│   │   └── SvgViewer.tsx    # SVGビューアー（react-svg-pan-zoom）
+│   ├── utils/               # ユーティリティ
+│   │   ├── gff.ts           # GFF3パーサー
+│   │   └── gff.test.ts      # GFFパーサーのテスト
+│   ├── api/                 # Next.js APIルート
+│   │   ├── list-gffs/       # GFFファイル一覧取得
+│   │   └── upload-gff/      # GFFファイルアップロード
 │   ├── docs/                # ドキュメントページ
 │   ├── faq/                 # FAQページ
 │   ├── page.tsx             # メインページ
-│   └── layout.tsx           # レイアウトコンポーネント
+│   └── layout.tsx           # ルートレイアウト
 ├── api/                      # バックエンド (FastAPI)
 │   ├── index.py             # FastAPI エンドポイント
-│   └── original.py          # CLIツール
+│   ├── models.py            # データモデル（GeneFeature、GeneStructure等）
+│   ├── drawer.py            # SVG描画ロジック
+│   └── parser.py            # パーサー
 ├── geneSTRUCTURE_v2/        # GFF3データ
 │   └── gff3/
 │       └── IRGSP-1.0_representative/
@@ -135,6 +150,7 @@ domains = [
 ├── requirements.txt         # Python依存関係
 ├── package.json             # Node.js依存関係
 ├── tsconfig.json            # TypeScript設定
+├── biome.json               # Biome設定（フォーマッター/リンター）
 ├── next.config.js           # Next.js設定
 └── README.md                # プロジェクト説明
 ```
@@ -142,16 +158,24 @@ domains = [
 ## 技術スタック
 
 ### フロントエンド
-- Next.js 14
-- React 18
+- Next.js 16
+- React 19
 - TypeScript
-- Tailwind CSS
+- Mantine v8（UIコンポーネント）
+- react-svg-pan-zoom（SVGビューアー）
+- gff-nostream（GFF3パーサー）
 
 ### バックエンド
 - FastAPI
 - Python 3.12
-- svgwrite (SVG生成)
-- reportlab (PDF生成)
+- svgwrite（SVG生成）
+- reportlab（PDF生成）
+- Pydantic（データバリデーション）
+
+### 開発ツール
+- Biome（フォーマッター/リンター）
+- Vitest（テスト）
+- mise（Node.jsバージョン管理）
 
 ## ライセンス
 


### PR DESCRIPTION
- 技術スタックをNext.js 16 + React 19 + Mantine v8に更新
- APIエンドポイントを/api/py/generate-gene-structure-svgに修正
- モジュール分割後のAPI構成（models.py、drawer.py、parser.py）を反映
- プロジェクト構成にapp/api/、app/utils/を追加
- 開発ツールセクションにBiome、Vitest、miseを追加