### PR TITLE
feat: 複数遺伝子選択とSVG縦並び生成機能を追加

### DIFF
--- a/api/drawer.py
+++ b/api/drawer.py
@@ -1,5 +1,6 @@
 import io
 import svgwrite
+from typing import List
 
 from .models import GeneStructure
 
@@ -177,6 +178,208 @@ def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_
             ))
         dwg.add(dwg.text(
             label,
+            insert=(legend_x + box_size + 5, y_legend + box_size - 2),
+            font_size='12px',
+            fill='black'
+        ))
+
+    return dwg.tostring()
+
+
+def draw_multiple_gene_structures(
+    genes: List[GeneStructure],
+    labels: List[str],
+    show_labels: bool = True,
+    gene_spacing: int = 50,
+    scale: float = 2,
+    shrink_factor: float = 30.0,
+    utr_color: str = None,
+    exon_color: str = None,
+    line_color: str = None,
+    domain_color: str = None
+) -> str:
+    """
+    複数の遺伝子構造を縦並びで1つのSVGに描画する
+
+    Args:
+        genes: 描画するGeneStructureのリスト
+        labels: 各遺伝子のラベル（transcript_id等）
+        show_labels: ラベルを表示するかどうか
+        gene_spacing: 遺伝子間の余白（ピクセル）
+        scale: スケール倍率
+        shrink_factor: 座標の縮小係数
+        utr_color: UTRの色
+        exon_color: Exon/CDSの色
+        line_color: イントロンの色
+        domain_color: ドメインの色
+
+    Returns:
+        SVG文字列
+    """
+    # デフォルト色を設定
+    utr_color = utr_color or DEFAULT_COLORS['utr_color']
+    exon_color = exon_color or DEFAULT_COLORS['exon_color']
+    line_color = line_color or DEFAULT_COLORS['line_color']
+    domain_color = domain_color or DEFAULT_COLORS['domain_color']
+
+    extra_padding = 100
+    height_feature = 15
+    label_width = 200 if show_labels else 0  # ラベル用のスペース
+
+    # 各遺伝子の最大X座標を計算
+    max_x_coords = []
+    gene_data = []
+
+    for gene in genes:
+        min_start = gene.to_relative()
+        all_features = gene.get_sorted_features()
+        if not all_features:
+            max_x_coords.append(0)
+            gene_data.append((all_features, 0, 0))
+            continue
+
+        max_end = max(f.end / shrink_factor for f in all_features)
+        shift = -min_start if min_start < 0 else 0
+        max_x_coord = LEFT_MARGIN + label_width + (max_end + shift / shrink_factor) * scale
+        max_x_coords.append(max_x_coord)
+        gene_data.append((all_features, shift, max_end))
+
+    # Canvas幅は最大のX座標 + 凡例スペース
+    global_max_x = max(max_x_coords) if max_x_coords else LEFT_MARGIN + label_width
+    canvas_width = global_max_x + extra_padding + 300
+
+    # Canvas高さ = (遺伝子高さ + 余白) × 遺伝子数 + 上下マージン
+    gene_height = height_feature + 10  # 遺伝子1つ分の高さ
+    top_margin = 30
+    canvas_height = top_margin + len(genes) * (gene_height + gene_spacing) + 150  # 凡例用スペース
+
+    # メモリ上にSVGを作成
+    dwg = svgwrite.Drawing(size=(canvas_width, canvas_height))
+
+    # 各遺伝子を描画
+    for idx, (gene, label) in enumerate(zip(genes, labels)):
+        all_features, shift, max_end = gene_data[idx]
+        y_pos = top_margin + idx * (gene_height + gene_spacing)
+
+        # ラベルを描画
+        if show_labels:
+            dwg.add(dwg.text(
+                label,
+                insert=(LEFT_MARGIN, y_pos + height_feature - 2),
+                font_size='11px',
+                fill='black',
+                font_family='monospace'
+            ))
+
+        # フィーチャーを描画（ドメイン以外）
+        for feat in all_features:
+            x_start = LEFT_MARGIN + label_width + (feat.start / shrink_factor + shift / shrink_factor) * scale
+            x_end = LEFT_MARGIN + label_width + (feat.end / shrink_factor + shift / shrink_factor) * scale
+            width = x_end - x_start
+
+            if feat.feature_type == 'domain':
+                continue
+
+            if feat.feature_type == 'deletion':
+                dwg.add(
+                    dwg.rect(
+                        insert=(x_start, y_pos),
+                        size=(width, height_feature),
+                        fill='none',
+                        stroke='red',
+                        stroke_dasharray="5,5",
+                        stroke_width=2
+                    )
+                )
+            elif feat.feature_type in ('exon', 'CDS', 'five_prime_UTR', 'three_prime_UTR'):
+                if feat.feature_type in ('five_prime_UTR', 'three_prime_UTR'):
+                    fill_color = utr_color
+                else:
+                    fill_color = exon_color
+
+                stroke_color = FEATURE_OUTLINES.get(feat.feature_type, 'black')
+                stroke_width = FEATURE_OUTLINE_WIDTHS.get(feat.feature_type, 1)
+                outline_enabled = FEATURE_OUTLINE_ENABLED.get(feat.feature_type, True)
+
+                dwg.add(
+                    dwg.rect(
+                        insert=(x_start, y_pos),
+                        size=(width, height_feature),
+                        fill=fill_color,
+                        stroke=stroke_color if outline_enabled else 'none',
+                        stroke_width=stroke_width
+                    )
+                )
+            elif feat.feature_type == 'intron':
+                if x_start < x_end:
+                    y_line = y_pos + height_feature // 2
+                    dwg.add(
+                        dwg.line(
+                            start=(x_start, y_line),
+                            end=(x_end, y_line),
+                            stroke=line_color,
+                            stroke_width=FEATURE_OUTLINE_WIDTHS.get('intron', 1)
+                        )
+                    )
+
+        # ドメインを描画（上層）
+        for feat in all_features:
+            if feat.feature_type == 'domain':
+                x_start = LEFT_MARGIN + label_width + (feat.start / shrink_factor + shift / shrink_factor) * scale
+                x_end = LEFT_MARGIN + label_width + (feat.end / shrink_factor + shift / shrink_factor) * scale
+                width = x_end - x_start
+
+                dwg.add(
+                    dwg.rect(
+                        insert=(x_start, y_pos),
+                        size=(width, height_feature),
+                        fill=domain_color,
+                        stroke=FEATURE_OUTLINES.get('domain', 'black'),
+                        stroke_width=FEATURE_OUTLINE_WIDTHS.get('domain', 1)
+                    )
+                )
+
+    # === 凡例（右上に1つだけ配置） ===
+    legend_x = global_max_x + 50
+    legend_y = 30
+    box_size = 12
+    spacing = 20
+    legend_items = [
+        ('domain', 'Domain', domain_color),
+        ('CDS', 'Exon/CDS', exon_color),
+        ('five_prime_UTR', "5' UTR", utr_color),
+        ('three_prime_UTR', "3' UTR", utr_color),
+        ('intron', 'Intron', line_color),
+        ('deletion', 'Deletion', None)
+    ]
+    for i, (feat_key, label_text, color) in enumerate(legend_items):
+        y_legend = legend_y + i * spacing
+        if feat_key == 'deletion':
+            dwg.add(dwg.rect(
+                insert=(legend_x, y_legend),
+                size=(box_size, box_size),
+                fill='none',
+                stroke='red',
+                stroke_dasharray="5,5",
+                stroke_width=2
+            ))
+        elif feat_key == 'intron':
+            y_line = y_legend + box_size // 2
+            dwg.add(dwg.line(
+                start=(legend_x, y_line),
+                end=(legend_x + box_size, y_line),
+                stroke=color,
+                stroke_width=FEATURE_OUTLINE_WIDTHS.get('intron', 1)
+            ))
+        else:
+            dwg.add(dwg.rect(
+                insert=(legend_x, y_legend),
+                size=(box_size, box_size),
+                fill=color,
+                stroke='black'
+            ))
+        dwg.add(dwg.text(
+            label_text,
             insert=(legend_x + box_size + 5, y_legend + box_size - 2),
             font_size='12px',
             fill='black'

--- a/api/index.py
+++ b/api/index.py
@@ -6,8 +6,10 @@ from .models import (
     GeneFeature,
     GeneStructure,
     GeneStructureRequest,
+    MultiGeneStructureRequest,
 )
-from .drawer import draw_gene_structure, DEFAULT_COLORS
+from .drawer import draw_gene_structure, draw_multiple_gene_structures, DEFAULT_COLORS
+from .utils import build_gene_structure
 
 
 ### Create FastAPI instance with custom docs and openapi url
@@ -154,6 +156,58 @@ async def generate_gene_structure_svg(request: GeneStructureRequest):
         draw_settings = request.draw_settings
         svg_content = draw_gene_structure(
             gene,
+            utr_color=draw_settings.utr_color,
+            exon_color=draw_settings.exon_color,
+            line_color=draw_settings.line_color,
+            domain_color=DEFAULT_COLORS['domain_color']
+        )
+
+        return Response(content=svg_content, media_type="image/svg+xml")
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/api/py/generate-multi-gene-structure-svg")
+async def generate_multi_gene_structure_svg(request: MultiGeneStructureRequest):
+    """
+    複数の遺伝子構造を1つのSVGに縦並びで描画するエンドポイント
+    """
+    try:
+        genes = []
+        labels = []
+
+        for gene_info in request.gene_structures:
+            # 共通関数でGeneStructureを構築
+            gene = build_gene_structure(gene_info)
+
+            # プロテインドメインを追加（最初の遺伝子のみに適用、オプション）
+            if request.protein_domain_start and request.protein_domain_end and request.protein_domain_name:
+                gene.add_domain_from_protein_coords(
+                    request.protein_domain_start,
+                    request.protein_domain_end,
+                    request.protein_domain_name
+                )
+
+            # ドメインを追加
+            if request.domains:
+                gene.add_domains(request.domains)
+
+            # デリーション処理
+            if request.deletion_regions:
+                deletion_regions_as_tuples = [tuple(r) for r in request.deletion_regions]
+                gene.update_features_with_deletions(deletion_regions_as_tuples)
+
+            genes.append(gene)
+            labels.append(gene_info.transcript_id)
+
+        # SVGを生成
+        draw_settings = request.draw_settings
+        svg_content = draw_multiple_gene_structures(
+            genes=genes,
+            labels=labels,
+            show_labels=request.show_labels,
+            gene_spacing=request.gene_spacing,
             utr_color=draw_settings.utr_color,
             exon_color=draw_settings.exon_color,
             line_color=draw_settings.line_color,

--- a/api/models.py
+++ b/api/models.py
@@ -304,3 +304,117 @@ class GeneStructureRequest(BaseModel):
             if start >= end:
                 raise ValueError(f"Domain {i}: start ({start}) must be less than end ({end})")
         return v
+
+
+class MultiGeneStructureRequest(BaseModel):
+    """複数遺伝子のSVG生成リクエスト"""
+    draw_settings: DrawSettings
+    gene_structures: List[GeneStructureInfo]
+    show_labels: bool = True
+    gene_spacing: int = 50  # 遺伝子間の余白（ピクセル）
+    deletion_regions: List[List[int]] = []
+    domains: List[Dict] = []
+    protein_domain_start: Optional[int] = None
+    protein_domain_end: Optional[int] = None
+    protein_domain_name: Optional[str] = None
+
+    @field_validator('gene_structures')
+    @classmethod
+    def validate_gene_structures(cls, v):
+        """gene_structuresのバリデーション"""
+        if len(v) == 0:
+            raise ValueError("At least one gene structure is required")
+        if len(v) > 30:
+            raise ValueError("Maximum 30 gene structures allowed")
+        return v
+
+    @field_validator('gene_spacing')
+    @classmethod
+    def validate_gene_spacing(cls, v):
+        """gene_spacingのバリデーション"""
+        if v < 0:
+            raise ValueError("gene_spacing must be non-negative")
+        if v > 500:
+            raise ValueError("gene_spacing must be 500 or less")
+        return v
+
+    @field_validator('deletion_regions')
+    @classmethod
+    def validate_deletion_regions(cls, v):
+        """deletion_regionsのバリデーション"""
+        for i, region in enumerate(v):
+            if len(region) != 2:
+                raise ValueError(f"Deletion region {i} must have exactly 2 elements [start, end]")
+            start, end = region
+            if start <= 0 or end <= 0:
+                raise ValueError(f"Deletion region {i}: coordinates must be positive integers (got start={start}, end={end})")
+            if start >= end:
+                raise ValueError(f"Deletion region {i}: start ({start}) must be less than end ({end})")
+        return v
+
+    @field_validator('protein_domain_start')
+    @classmethod
+    def validate_protein_domain_start(cls, v):
+        """protein_domain_startのバリデーション"""
+        if v is not None and v <= 0:
+            raise ValueError(f"protein_domain_start must be a positive integer (got {v})")
+        return v
+
+    @field_validator('protein_domain_end')
+    @classmethod
+    def validate_protein_domain_end(cls, v):
+        """protein_domain_endのバリデーション"""
+        if v is not None and v <= 0:
+            raise ValueError(f"protein_domain_end must be a positive integer (got {v})")
+        return v
+
+    @model_validator(mode='after')
+    def validate_protein_domain(self):
+        """protein domainの整合性チェック"""
+        start = self.protein_domain_start
+        end = self.protein_domain_end
+        name = self.protein_domain_name
+
+        # 3つのうち1つでも設定されている場合、すべてが必要
+        if any([start, end, name]):
+            if not all([start, end, name]):
+                raise ValueError(
+                    "protein_domain_start, protein_domain_end, and protein_domain_name must all be provided together"
+                )
+            if start >= end:
+                raise ValueError(
+                    f"protein_domain_start ({start}) must be less than protein_domain_end ({end})"
+                )
+        return self
+
+    @field_validator('domains')
+    @classmethod
+    def validate_domains(cls, v):
+        """domainsのバリデーション"""
+        for i, domain in enumerate(v):
+            # 必須フィールドのチェック
+            if 'start' not in domain:
+                raise ValueError(f"Domain {i}: 'start' field is required")
+            if 'end' not in domain:
+                raise ValueError(f"Domain {i}: 'end' field is required")
+            if 'name' not in domain:
+                raise ValueError(f"Domain {i}: 'name' field is required")
+
+            start = domain['start']
+            end = domain['end']
+            name = domain['name']
+
+            # 型チェック
+            if not isinstance(start, int):
+                raise ValueError(f"Domain {i}: 'start' must be an integer (got {type(start).__name__})")
+            if not isinstance(end, int):
+                raise ValueError(f"Domain {i}: 'end' must be an integer (got {type(end).__name__})")
+            if not isinstance(name, str):
+                raise ValueError(f"Domain {i}: 'name' must be a string (got {type(name).__name__})")
+
+            # 範囲チェック
+            if start <= 0 or end <= 0:
+                raise ValueError(f"Domain {i}: coordinates must be positive integers (got start={start}, end={end})")
+            if start >= end:
+                raise ValueError(f"Domain {i}: start ({start}) must be less than end ({end})")
+        return v

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,0 +1,114 @@
+from .models import GeneFeature, GeneStructure, GeneStructureInfo
+
+
+def build_gene_structure(gene_info: GeneStructureInfo) -> GeneStructure:
+    """
+    GeneStructureInfoからGeneStructureオブジェクトを構築する共通関数
+
+    Args:
+        gene_info: フロントエンドから送られたGeneStructureInfo
+
+    Returns:
+        構築されたGeneStructureオブジェクト（イントロン追加済み、相対座標変換済み）
+    """
+    gene = GeneStructure(
+        gene_id=gene_info.transcript_id,
+        seqid=gene_info.seq_id or "",
+        strand=gene_info.strand or "+"
+    )
+
+    # Exonを追加
+    for exon in gene_info.exons:
+        if gene_info.strand == '-':
+            feature = GeneFeature(
+                gene_info.seq_id or "",
+                exon.end * -1,
+                exon.start * -1,
+                'exon',
+                gene_info.strand or "+",
+                {}
+            )
+        else:
+            feature = GeneFeature(
+                gene_info.seq_id or "",
+                exon.start,
+                exon.end,
+                'exon',
+                gene_info.strand or "+",
+                {}
+            )
+        gene.add_feature(feature)
+
+    # CDSを追加
+    for cds in gene_info.cds:
+        if gene_info.strand == '-':
+            feature = GeneFeature(
+                gene_info.seq_id or "",
+                cds.end * -1,
+                cds.start * -1,
+                'CDS',
+                gene_info.strand or "+",
+                {}
+            )
+        else:
+            feature = GeneFeature(
+                gene_info.seq_id or "",
+                cds.start,
+                cds.end,
+                'CDS',
+                gene_info.strand or "+",
+                {}
+            )
+        gene.add_feature(feature)
+
+    # 5' UTRを追加
+    for utr in gene_info.five_prime_utrs:
+        if gene_info.strand == '-':
+            feature = GeneFeature(
+                gene_info.seq_id or "",
+                utr.end * -1,
+                utr.start * -1,
+                'five_prime_UTR',
+                gene_info.strand or "+",
+                {}
+            )
+        else:
+            feature = GeneFeature(
+                gene_info.seq_id or "",
+                utr.start,
+                utr.end,
+                'five_prime_UTR',
+                gene_info.strand or "+",
+                {}
+            )
+        gene.add_feature(feature)
+
+    # 3' UTRを追加
+    for utr in gene_info.three_prime_utrs:
+        if gene_info.strand == '-':
+            feature = GeneFeature(
+                gene_info.seq_id or "",
+                utr.end * -1,
+                utr.start * -1,
+                'three_prime_UTR',
+                gene_info.strand or "+",
+                {}
+            )
+        else:
+            feature = GeneFeature(
+                gene_info.seq_id or "",
+                utr.start,
+                utr.end,
+                'three_prime_UTR',
+                gene_info.strand or "+",
+                {}
+            )
+        gene.add_feature(feature)
+
+    # イントロンを追加
+    gene.add_introns()
+
+    # 相対座標に変換
+    gene.to_relative()
+
+    return gene

--- a/app/components/GeneSelector.tsx
+++ b/app/components/GeneSelector.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  Alert,
+  Autocomplete,
+  Badge,
+  Box,
+  Button,
+  Group,
+  Stack,
+  Text,
+} from "@mantine/core";
+import {
+  IconAlertCircle,
+  IconGripVertical,
+  IconTrash,
+  IconX,
+} from "@tabler/icons-react";
+import Fuse from "fuse.js";
+import { useMemo, useState } from "react";
+import type { GeneStructureInfo } from "../utils/gff";
+
+interface GeneSelectorProps {
+  geneStructures: GeneStructureInfo[];
+  selectedTranscripts: string[];
+  onSelectionChange: (transcripts: string[]) => void;
+  maxSelection?: number;
+  disabled?: boolean;
+}
+
+interface SortableItemProps {
+  id: string;
+  onRemove: (id: string) => void;
+  disabled?: boolean;
+}
+
+function SortableItem({ id, onRemove, disabled }: SortableItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    borderRadius: "4px",
+    border: "1px solid var(--mantine-color-gray-3)",
+    cursor: disabled ? "default" : "grab",
+  };
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      p="xs"
+      mb="xs"
+      bg="gray.0"
+    >
+      <Group justify="space-between" wrap="nowrap">
+        <Group wrap="nowrap" gap="xs">
+          <Box
+            {...listeners}
+            style={{
+              cursor: disabled ? "not-allowed" : "grab",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <IconGripVertical size={16} color="gray" />
+          </Box>
+          <Text size="sm" style={{ fontFamily: "monospace" }}>
+            {id}
+          </Text>
+        </Group>
+        <Button
+          size="compact-xs"
+          variant="subtle"
+          color="red"
+          onClick={() => onRemove(id)}
+          disabled={disabled}
+        >
+          <IconX size={14} />
+        </Button>
+      </Group>
+    </Box>
+  );
+}
+
+export function GeneSelector({
+  geneStructures,
+  selectedTranscripts,
+  onSelectionChange,
+  maxSelection = 30,
+  disabled = false,
+}: GeneSelectorProps) {
+  const [input, setInput] = useState("");
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const fuseInstance = useMemo(() => {
+    return new Fuse(geneStructures, {
+      keys: ["transcript_id", "attributes.Parent"],
+      threshold: 0.5,
+    });
+  }, [geneStructures]);
+
+  const autocompleteOptions = useMemo(() => {
+    if (!input) {
+      return geneStructures
+        .filter((gs) => !selectedTranscripts.includes(gs.transcript_id))
+        .slice(0, 50)
+        .map((gs) => gs.transcript_id);
+    }
+
+    const results = fuseInstance.search(input);
+    return results
+      .filter((r) => !selectedTranscripts.includes(r.item.transcript_id))
+      .slice(0, 50)
+      .map((r) => r.item.transcript_id);
+  }, [geneStructures, fuseInstance, input, selectedTranscripts]);
+
+  const handleSelect = (value: string) => {
+    if (
+      value &&
+      !selectedTranscripts.includes(value) &&
+      selectedTranscripts.length < maxSelection
+    ) {
+      onSelectionChange([...selectedTranscripts, value]);
+      setInput("");
+    }
+  };
+
+  const handleRemove = (transcriptId: string) => {
+    onSelectionChange(selectedTranscripts.filter((id) => id !== transcriptId));
+  };
+
+  const handleClearAll = () => {
+    onSelectionChange([]);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = selectedTranscripts.indexOf(active.id as string);
+      const newIndex = selectedTranscripts.indexOf(over.id as string);
+      onSelectionChange(arrayMove(selectedTranscripts, oldIndex, newIndex));
+    }
+  };
+
+  const isAtLimit = selectedTranscripts.length >= maxSelection;
+
+  return (
+    <Stack gap="sm">
+      <Autocomplete
+        label="Transcript ID"
+        placeholder={
+          isAtLimit
+            ? `Maximum ${maxSelection} genes selected`
+            : "Search and select genes..."
+        }
+        data={autocompleteOptions}
+        value={input}
+        onChange={setInput}
+        onOptionSubmit={handleSelect}
+        disabled={disabled || isAtLimit}
+        limit={50}
+      />
+
+      {isAtLimit && (
+        <Alert
+          icon={<IconAlertCircle size={16} />}
+          color="orange"
+          variant="light"
+        >
+          Maximum of {maxSelection} genes can be selected.
+        </Alert>
+      )}
+
+      {selectedTranscripts.length > 0 && (
+        <>
+          <Group justify="space-between">
+            <Text size="sm" c="dimmed">
+              Selected: {selectedTranscripts.length} / {maxSelection}
+            </Text>
+            <Button
+              size="compact-xs"
+              variant="subtle"
+              color="red"
+              leftSection={<IconTrash size={14} />}
+              onClick={handleClearAll}
+              disabled={disabled}
+            >
+              Clear All
+            </Button>
+          </Group>
+
+          <Text size="xs" c="dimmed">
+            Drag to reorder
+          </Text>
+
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={selectedTranscripts}
+              strategy={verticalListSortingStrategy}
+            >
+              <Box
+                style={{
+                  maxHeight: "300px",
+                  overflowY: "auto",
+                  padding: "4px",
+                }}
+              >
+                {selectedTranscripts.map((id) => (
+                  <SortableItem
+                    key={id}
+                    id={id}
+                    onRemove={handleRemove}
+                    disabled={disabled}
+                  />
+                ))}
+              </Box>
+            </SortableContext>
+          </DndContext>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import {
-  Autocomplete,
-  Badge,
   Button,
   Card,
   Code,
@@ -12,12 +10,12 @@ import {
   Group,
   Modal,
   NumberInput,
-  Paper,
   Select,
+  Slider,
   Stack,
+  Switch,
   Text,
   TextInput,
-  ThemeIcon,
   Title,
 } from "@mantine/core";
 import { Dropzone } from "@mantine/dropzone";
@@ -30,10 +28,10 @@ import {
   IconRefresh,
   IconX,
 } from "@tabler/icons-react";
-import Fuse from "fuse.js";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 
+import { GeneSelector } from "./components/GeneSelector";
 import SvgViewer from "./components/SvgViewer";
 import {
   type GeneStructureInfo as ApiGeneStructureInfo,
@@ -51,11 +49,76 @@ import {
 
 type UIState = "upload" | "preview";
 
+type MultiGeneStructureRequest = {
+  draw_settings: {
+    mode: string;
+    utr_color: string;
+    exon_color: string;
+    line_color: string;
+    intron_shape: string;
+  };
+  gene_structures: ApiGeneStructureInfo[];
+  show_labels: boolean;
+  gene_spacing: number;
+  deletion_regions?: number[][];
+  domains?: { start: number; end: number; name: string }[];
+  protein_domain_start?: number;
+  protein_domain_end?: number;
+  protein_domain_name?: string;
+};
+
 type ExportSettings = {
   format: "svg" | "png";
   dpi: number;
   background: "transparent" | "white";
   filename: string;
+};
+
+const postMultiFetcher = async (data: MultiGeneStructureRequest | null) => {
+  if (!data) {
+    throw new Error("No data provided");
+  }
+
+  const response = await fetch("/api/py/generate-multi-gene-structure-svg", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    if (response.status === 422) {
+      const errorData = await response.json();
+      if (errorData.detail && Array.isArray(errorData.detail)) {
+        const errorMessages = errorData.detail
+          .map((err: { loc?: string[]; msg: string }) => {
+            const field = err.loc?.join(".") || "unknown";
+            return `${field}: ${err.msg}`;
+          })
+          .join("\n");
+
+        notifications.show({
+          title: "Validation Error",
+          message: errorMessages,
+          color: "red",
+          autoClose: 10000,
+        });
+        throw new Error("Validation error");
+      }
+    }
+
+    notifications.show({
+      title: "Error",
+      message: `API error: ${response.status}`,
+      color: "red",
+      autoClose: 5000,
+    });
+    throw new Error(`API error: ${response.status}`);
+  }
+
+  const blob = await response.blob();
+  return { blob, url: window.URL.createObjectURL(blob) };
 };
 
 const postFetcher = async (data: GeneStructureRequest | null) => {
@@ -102,7 +165,6 @@ const postFetcher = async (data: GeneStructureRequest | null) => {
 export default function Home() {
   const [uiState, setUiState] = useState<UIState>("upload");
   const [isLoading, setIsLoading] = useState(false);
-  const [input, setInput] = useState("");
   const [selectedTranscripts, setSelectedTranscripts] = useState<string[]>([]);
   const [utrColor, setUtrColor] = useState("#d3d3d3");
   const [exonColor, setExonColor] = useState("#000000");
@@ -114,7 +176,6 @@ export default function Home() {
   const [presetGffOptions, setPresetGffOptions] = useState<
     Array<{ group: string; items: Array<{ value: string; label: string }> }>
   >([]);
-  const [width, setWidth] = useState(1200);
   const [geneStructures, setGeneStructures] = useState<GeneStructureInfo[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -125,6 +186,10 @@ export default function Home() {
     background: "white",
     filename: "gene_structure",
   });
+
+  // Multi-gene settings
+  const [showLabels, setShowLabels] = useState(true);
+  const [geneSpacing, setGeneSpacing] = useState(50);
 
   // Deletion and domain settings
   const [deletionRegions, setDeletionRegions] = useState<
@@ -216,31 +281,6 @@ export default function Home() {
     }
   };
 
-  const fuseInstance = useMemo(() => {
-    const fuse = new Fuse(geneStructures, {
-      keys: ["transcript_id", "attributes.Parent"],
-      threshold: 0.5,
-    });
-    return fuse;
-  }, [geneStructures]);
-
-  const autocompleteData = useMemo(() => {
-    if (!input) {
-      return geneStructures
-        .filter((gs) => !selectedTranscripts.includes(gs.transcript_id))
-        .slice(0, 20)
-        .map((gs) => gs.transcript_id);
-    }
-
-    const searchResults = fuseInstance.search(input);
-    return searchResults
-      .filter(
-        (result) => !selectedTranscripts.includes(result.item.transcript_id),
-      )
-      .slice(0, 20)
-      .map((result) => result.item.transcript_id);
-  }, [geneStructures, selectedTranscripts, input, fuseInstance]);
-
   // ファイル処理関数（アップロード→解析）
   const handleFileProcess = async () => {
     if (!selectedFile) {
@@ -267,7 +307,7 @@ export default function Home() {
 
       // 処理完了後、UI状態を生成画面に変更
       setUiState("preview");
-      await handleGenerateSVG(geneStructures[0]);
+      await handleGenerateSVG();
     } catch (error) {
       console.error("Error processing file:", error);
       notifications.show({
@@ -281,17 +321,18 @@ export default function Home() {
     }
   };
 
-  const getRequestData = (): GeneStructureRequest | null => {
+  const getMultiRequestData = (): MultiGeneStructureRequest | null => {
     if (geneStructures.length === 0) return null;
     if (selectedTranscripts.length === 0) return null;
 
-    const selectedGeneStructure = geneStructures.find((gs) =>
-      selectedTranscripts.includes(gs.transcript_id),
-    );
+    // 選択順序を維持して遺伝子構造を取得
+    const selectedGeneStructures = selectedTranscripts
+      .map((id) => geneStructures.find((gs) => gs.transcript_id === id))
+      .filter((gs): gs is GeneStructureInfo => gs !== undefined);
 
-    if (!selectedGeneStructure) return null;
+    if (selectedGeneStructures.length === 0) return null;
 
-    const requestData: GeneStructureRequest = {
+    const requestData: MultiGeneStructureRequest = {
       draw_settings: {
         mode: "domain",
         utr_color: utrColor,
@@ -299,7 +340,9 @@ export default function Home() {
         line_color: lineColor,
         intron_shape: "straight",
       },
-      gene_structure: selectedGeneStructure as ApiGeneStructureInfo,
+      gene_structures: selectedGeneStructures as ApiGeneStructureInfo[],
+      show_labels: showLabels,
+      gene_spacing: geneSpacing,
       deletion_regions: [],
       domains: [],
     };
@@ -331,10 +374,12 @@ export default function Home() {
 
   const { data: svgData, mutate: mutateSVG } = useSWR(
     () => {
-      const requestData = getRequestData();
-      return requestData ? ["generate-gene-structure-svg", requestData] : null;
+      const requestData = getMultiRequestData();
+      return requestData
+        ? ["generate-multi-gene-structure-svg", requestData]
+        : null;
     },
-    ([_key, data]) => postFetcher(data),
+    ([_key, data]) => postMultiFetcher(data),
     {
       onSuccess: (data) => {
         renderSvgToCanvas(data.url);
@@ -342,11 +387,11 @@ export default function Home() {
     },
   );
 
-  const handleGenerateSVG = async (structure: GeneStructureInfo | null) => {
-    if (!structure) {
+  const handleGenerateSVG = async () => {
+    if (selectedTranscripts.length === 0) {
       notifications.show({
         title: "Error",
-        message: "Please process the file first",
+        message: "Please select at least one gene",
         color: "red",
         autoClose: 5000,
       });
@@ -569,70 +614,16 @@ Chr1 TAIR10 exon 3996 4276 . + . Parent=AT1G01010.1`}
               <Grid.Col span={6}>
                 <Card shadow="xl" padding="lg" radius="md" mb={32} h="100%">
                   <Title order={3} mb="md">
-                    Search Genes/Transcripts
+                    Select Genes/Transcripts
                   </Title>
 
-                  <Stack>
-                    <Autocomplete
-                      label=""
-                      placeholder="Select gene ID/transcript ID"
-                      disabled={!geneStructures.length}
-                      value={input}
-                      onChange={setInput}
-                      data={autocompleteData}
-                      onOptionSubmit={(value) => {
-                        if (!selectedTranscripts.includes(value)) {
-                          setSelectedTranscripts([
-                            ...selectedTranscripts,
-                            value,
-                          ]);
-                          setInput("");
-                        }
-                      }}
-                    />
-
-                    {selectedTranscripts.length > 0 && (
-                      <>
-                        <Text size="sm" fw={500}>
-                          Selected Transcripts:
-                        </Text>
-                        <Stack gap="xs">
-                          {selectedTranscripts.map((transcript) => (
-                            <Badge
-                              key={transcript}
-                              size="lg"
-                              style={{ textTransform: "none" }}
-                              rightSection={
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    setSelectedTranscripts(
-                                      selectedTranscripts.filter(
-                                        (t) => t !== transcript,
-                                      ),
-                                    );
-                                  }}
-                                  style={{
-                                    border: "none",
-                                    background: "transparent",
-                                    cursor: "pointer",
-                                    padding: 0,
-                                    marginLeft: 4,
-                                    color: "white",
-                                    fontSize: 20,
-                                  }}
-                                >
-                                  ×
-                                </button>
-                              }
-                            >
-                              {transcript}
-                            </Badge>
-                          ))}
-                        </Stack>
-                      </>
-                    )}
-                  </Stack>
+                  <GeneSelector
+                    geneStructures={geneStructures}
+                    selectedTranscripts={selectedTranscripts}
+                    onSelectionChange={setSelectedTranscripts}
+                    maxSelection={30}
+                    disabled={!geneStructures.length || isLoading}
+                  />
                 </Card>
               </Grid.Col>
             </Grid>
@@ -673,7 +664,7 @@ Chr1 TAIR10 exon 3996 4276 . + . Parent=AT1G01010.1`}
                   </Title>
                   <Stack gap="md">
                     <Button
-                      onClick={() => handleGenerateSVG(geneStructures[0])}
+                      onClick={() => handleGenerateSVG()}
                       disabled={isLoading}
                       loading={isLoading}
                       leftSection={<IconPlayerPlay size={16} />}
@@ -704,12 +695,44 @@ Chr1 TAIR10 exon 3996 4276 . + . Parent=AT1G01010.1`}
 
                 <Card shadow="xl" padding="lg" radius="md">
                   <Title order={3} mb="md">
-                    Basic Settings
+                    Multi-Gene Settings
+                  </Title>
+                  <Stack gap="md">
+                    <Switch
+                      label="Show gene labels"
+                      checked={showLabels}
+                      onChange={(event) =>
+                        setShowLabels(event.currentTarget.checked)
+                      }
+                    />
+                    <Stack gap="xs">
+                      <Text size="sm" fw={500}>
+                        Gene spacing: {geneSpacing}px
+                      </Text>
+                      <Slider
+                        value={geneSpacing}
+                        onChange={setGeneSpacing}
+                        min={10}
+                        max={200}
+                        step={5}
+                        marks={[
+                          { value: 10, label: "10" },
+                          { value: 100, label: "100" },
+                          { value: 200, label: "200" },
+                        ]}
+                      />
+                    </Stack>
+                    <Text size="xs" c="dimmed">
+                      Selected: {selectedTranscripts.length} gene(s)
+                    </Text>
+                  </Stack>
+                </Card>
+
+                <Card shadow="xl" padding="lg" radius="md">
+                  <Title order={3} mb="md">
+                    Color Settings
                   </Title>
                   <Stack>
-                    <Text size="sm" fw={500}>
-                      Color Settings:
-                    </Text>
                     <Grid>
                       <Grid.Col span={4}>
                         <ColorInput

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "nextjs-fastapi",
       "version": "0.2.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@mantine/core": "^8.3.6",
         "@mantine/dropzone": "^8.3.6",
         "@mantine/hooks": "^8.3.6",
@@ -283,6 +286,59 @@
       "license": "MIT",
       "peerDependencies": {
         "commander": "~14.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "fetch:openapi": "curl -s http://127.0.0.1:8000/api/py/openapi.json > openapi.json"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@mantine/core": "^8.3.6",
     "@mantine/dropzone": "^8.3.6",
     "@mantine/hooks": "^8.3.6",


### PR DESCRIPTION
## Summary
- MultiSelectで最大30個の遺伝子を選択可能に
- @dnd-kitによるドラッグ&ドロップで並び替え対応
- 遺伝子ラベル表示のON/OFF切り替え、SVG間の余白調整機能

## 変更内容
### バックエンド
- `api/models.py`: `MultiGeneStructureRequest` モデル追加
- `api/utils.py`: 共通関数 `build_gene_structure()` を新規作成
- `api/drawer.py`: `draw_multiple_gene_structures()` 関数追加
- `api/index.py`: `/api/py/generate-multi-gene-structure-svg` エンドポイント追加

### フロントエンド
- `app/components/GeneSelector.tsx`: 新規作成（MultiSelect + ドラッグ&ドロップ）
- `app/page.tsx`: 複数遺伝子対応UI統合、設定項目追加

## Test plan
- [ ] 開発サーバー起動 (`npm run dev`)
- [ ] GFFファイルアップロード
- [ ] 複数遺伝子選択（最大30件）
- [ ] ドラッグ&ドロップで並び替え
- [ ] ラベル表示切り替え
- [ ] 余白スライダー調整
- [ ] SVGプレビュー・ダウンロード

🤖 Generated with [Claude Code](https://claude.com/claude-code)