### PR TITLE
ci: add GitHub Actions workflow for OpenAPI type generation

### DIFF
--- a/.github/workflows/generate-api-types.yml
+++ b/.github/workflows/generate-api-types.yml
@@ -1,0 +1,50 @@
+name: Generate API Types
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'api/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Export OpenAPI schema
+        run: python scripts/export_openapi.py
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate API types from OpenAPI
+        run: npm run generate:api
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'ci: update openapi client'
+          file_pattern: 'openapi.json app/lib/api/generated/**'
+          commit_user_name: github-actions[bot]
+          commit_user_email: github-actions[bot]@users.noreply.github.com

--- a/openapi.json
+++ b/openapi.json
@@ -1,1 +1,533 @@
-{"openapi":"3.1.0","info":{"title":"FastAPI","version":"0.1.0"},"paths":{"/api/py/generate-gene-structure-svg":{"post":{"summary":"Generate Gene Structure Svg","description":"フロントエンドから送られたGeneStructureInfoを基に遺伝子構造を描画するエンドポイント","operationId":"generate_gene_structure_svg_api_py_generate_gene_structure_svg_post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/GeneStructureRequest"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/":{"get":{"summary":"Root","operationId":"root__get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}}},"components":{"schemas":{"DrawSettings":{"properties":{"mode":{"type":"string","title":"Mode"},"utr_color":{"type":"string","title":"Utr Color"},"exon_color":{"type":"string","title":"Exon Color"},"line_color":{"type":"string","title":"Line Color"},"intron_shape":{"type":"string","title":"Intron Shape"},"gene_height":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Gene Height"},"margin_x":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Margin X"},"margin_y":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Margin Y"}},"type":"object","required":["mode","utr_color","exon_color","line_color","intron_shape"],"title":"DrawSettings"},"GeneStructureInfo":{"properties":{"seq_id":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Seq Id"},"source":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Source"},"type":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Type"},"start":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Start"},"end":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"End"},"score":{"anyOf":[{"type":"number"},{"type":"null"}],"title":"Score"},"strand":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Strand"},"phase":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Phase"},"attributes":{"anyOf":[{"type":"object"},{"type":"null"}],"title":"Attributes"},"transcript_id":{"type":"string","title":"Transcript Id"},"total_length":{"type":"integer","title":"Total Length"},"exons":{"items":{"$ref":"#/components/schemas/Position"},"type":"array","title":"Exons"},"cds":{"items":{"$ref":"#/components/schemas/Position"},"type":"array","title":"Cds"},"five_prime_utrs":{"items":{"$ref":"#/components/schemas/Position"},"type":"array","title":"Five Prime Utrs"},"three_prime_utrs":{"items":{"$ref":"#/components/schemas/Position"},"type":"array","title":"Three Prime Utrs"}},"type":"object","required":["transcript_id","total_length","exons","cds","five_prime_utrs","three_prime_utrs"],"title":"GeneStructureInfo"},"GeneStructureRequest":{"properties":{"draw_settings":{"$ref":"#/components/schemas/DrawSettings"},"gene_structure":{"$ref":"#/components/schemas/GeneStructureInfo"},"deletion_regions":{"items":{"items":{"type":"integer"},"type":"array"},"type":"array","title":"Deletion Regions","default":[]},"domains":{"items":{"type":"object"},"type":"array","title":"Domains","default":[]},"protein_domain_start":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Protein Domain Start"},"protein_domain_end":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Protein Domain End"},"protein_domain_name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Protein Domain Name"}},"type":"object","required":["draw_settings","gene_structure"],"title":"GeneStructureRequest"},"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"Position":{"properties":{"start":{"type":"integer","title":"Start"},"end":{"type":"integer","title":"End"}},"type":"object","required":["start","end"],"title":"Position"},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/py/generate-gene-structure-svg": {
+      "post": {
+        "summary": "Generate Gene Structure Svg",
+        "description": "\u30d5\u30ed\u30f3\u30c8\u30a8\u30f3\u30c9\u304b\u3089\u9001\u3089\u308c\u305fGeneStructureInfo\u3092\u57fa\u306b\u907a\u4f1d\u5b50\u69cb\u9020\u3092\u63cf\u753b\u3059\u308b\u30a8\u30f3\u30c9\u30dd\u30a4\u30f3\u30c8",
+        "operationId": "generate_gene_structure_svg_api_py_generate_gene_structure_svg_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GeneStructureRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/py/generate-multi-gene-structure-svg": {
+      "post": {
+        "summary": "Generate Multi Gene Structure Svg",
+        "description": "\u8907\u6570\u306e\u907a\u4f1d\u5b50\u69cb\u9020\u30921\u3064\u306eSVG\u306b\u7e26\u4e26\u3073\u3067\u63cf\u753b\u3059\u308b\u30a8\u30f3\u30c9\u30dd\u30a4\u30f3\u30c8",
+        "operationId": "generate_multi_gene_structure_svg_api_py_generate_multi_gene_structure_svg_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultiGeneStructureRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Root",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DrawSettings": {
+        "properties": {
+          "mode": {
+            "type": "string",
+            "title": "Mode"
+          },
+          "utr_color": {
+            "type": "string",
+            "title": "Utr Color"
+          },
+          "exon_color": {
+            "type": "string",
+            "title": "Exon Color"
+          },
+          "line_color": {
+            "type": "string",
+            "title": "Line Color"
+          },
+          "intron_shape": {
+            "type": "string",
+            "title": "Intron Shape"
+          },
+          "gene_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gene Height"
+          },
+          "margin_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Margin X"
+          },
+          "margin_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Margin Y"
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode",
+          "utr_color",
+          "exon_color",
+          "line_color",
+          "intron_shape"
+        ],
+        "title": "DrawSettings"
+      },
+      "GeneStructureInfo": {
+        "properties": {
+          "seq_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seq Id"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "start": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "strand": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strand"
+          },
+          "phase": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase"
+          },
+          "attributes": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attributes"
+          },
+          "transcript_id": {
+            "type": "string",
+            "title": "Transcript Id"
+          },
+          "total_length": {
+            "type": "integer",
+            "title": "Total Length"
+          },
+          "exons": {
+            "items": {
+              "$ref": "#/components/schemas/Position"
+            },
+            "type": "array",
+            "title": "Exons"
+          },
+          "cds": {
+            "items": {
+              "$ref": "#/components/schemas/Position"
+            },
+            "type": "array",
+            "title": "Cds"
+          },
+          "five_prime_utrs": {
+            "items": {
+              "$ref": "#/components/schemas/Position"
+            },
+            "type": "array",
+            "title": "Five Prime Utrs"
+          },
+          "three_prime_utrs": {
+            "items": {
+              "$ref": "#/components/schemas/Position"
+            },
+            "type": "array",
+            "title": "Three Prime Utrs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "transcript_id",
+          "total_length",
+          "exons",
+          "cds",
+          "five_prime_utrs",
+          "three_prime_utrs"
+        ],
+        "title": "GeneStructureInfo"
+      },
+      "GeneStructureRequest": {
+        "properties": {
+          "draw_settings": {
+            "$ref": "#/components/schemas/DrawSettings"
+          },
+          "gene_structure": {
+            "$ref": "#/components/schemas/GeneStructureInfo"
+          },
+          "deletion_regions": {
+            "items": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "type": "array",
+            "title": "Deletion Regions",
+            "default": []
+          },
+          "domains": {
+            "items": {
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Domains",
+            "default": []
+          },
+          "protein_domain_start": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protein Domain Start"
+          },
+          "protein_domain_end": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protein Domain End"
+          },
+          "protein_domain_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protein Domain Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "draw_settings",
+          "gene_structure"
+        ],
+        "title": "GeneStructureRequest"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "MultiGeneStructureRequest": {
+        "properties": {
+          "draw_settings": {
+            "$ref": "#/components/schemas/DrawSettings"
+          },
+          "gene_structures": {
+            "items": {
+              "$ref": "#/components/schemas/GeneStructureInfo"
+            },
+            "type": "array",
+            "title": "Gene Structures"
+          },
+          "show_labels": {
+            "type": "boolean",
+            "title": "Show Labels",
+            "default": true
+          },
+          "gene_spacing": {
+            "type": "integer",
+            "title": "Gene Spacing",
+            "default": 50
+          },
+          "deletion_regions": {
+            "items": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "type": "array",
+            "title": "Deletion Regions",
+            "default": []
+          },
+          "domains": {
+            "items": {
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Domains",
+            "default": []
+          },
+          "protein_domain_start": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protein Domain Start"
+          },
+          "protein_domain_end": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protein Domain End"
+          },
+          "protein_domain_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protein Domain Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "draw_settings",
+          "gene_structures"
+        ],
+        "title": "MultiGeneStructureRequest",
+        "description": "\u8907\u6570\u907a\u4f1d\u5b50\u306eSVG\u751f\u6210\u30ea\u30af\u30a8\u30b9\u30c8"
+      },
+      "Position": {
+        "properties": {
+          "start": {
+            "type": "integer",
+            "title": "Start"
+          },
+          "end": {
+            "type": "integer",
+            "title": "End"
+          }
+        },
+        "type": "object",
+        "required": [
+          "start",
+          "end"
+        ],
+        "title": "Position"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fmt": "biome check --write ./app",
     "ts": "tsc --noEmit",
     "generate:api": "orval",
-    "fetch:openapi": "curl -s http://127.0.0.1:8000/api/py/openapi.json > openapi.json"
+    "fetch:openapi": "python3 scripts/export_openapi.py"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,13 @@
+import json
+import sys
+from pathlib import Path
+
+# プロジェクトルートをPYTHONPATHに追加
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from api.index import app
+
+openapi_schema = app.openapi()
+
+with open("openapi.json", "w") as f:
+    json.dump(openapi_schema, f, indent=2)


### PR DESCRIPTION
## Summary
- Add `scripts/export_openapi.py` to generate OpenAPI schema directly from FastAPI without server startup
- Update `fetch:openapi` npm script to use Python script instead of curl
- Add `generate-api-types.yml` GitHub Actions workflow to auto-generate and commit types on `api/**` changes

## Test plan
- [ ] Run `npm run fetch:openapi` locally to verify OpenAPI schema generation
- [ ] Trigger workflow manually via GitHub Actions UI
- [ ] Verify auto-commit on `api/**` file changes to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)