### PR TITLE
refactor: Display Optionsセクションの表示条件を改善

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -187,7 +187,7 @@ export default function Home() {
     filename: "gene_structure",
   });
 
-  // Multi-gene settings
+  // Display options
   const [showLabels, setShowLabels] = useState(true);
   const [geneSpacing, setGeneSpacing] = useState(50);
   const [labelSpacing, setLabelSpacing] = useState(10);
@@ -659,7 +659,7 @@ Chr1 TAIR10 exon 3996 4276 . + . Parent=AT1G01010.1`}
 
                 <Card shadow="xl" padding="lg" radius="md">
                   <Title order={3} mb="md">
-                    Multi-Gene Settings
+                    Display Options
                   </Title>
                   <Stack gap="md">
                     <Switch
@@ -669,43 +669,44 @@ Chr1 TAIR10 exon 3996 4276 . + . Parent=AT1G01010.1`}
                         setShowLabels(event.currentTarget.checked)
                       }
                     />
-                    <Stack gap="xs">
-                      <Text size="sm" fw={500}>
-                        Gene spacing: {geneSpacing}px
-                      </Text>
-                      <Slider
-                        value={geneSpacing}
-                        onChange={setGeneSpacing}
-                        min={10}
-                        max={200}
-                        step={5}
-                        marks={[
-                          { value: 10, label: "10" },
-                          { value: 100, label: "100" },
-                          { value: 200, label: "200" },
-                        ]}
-                      />
-                    </Stack>
-                    <Stack gap="xs">
-                      <Text size="sm" fw={500}>
-                        Label spacing: {labelSpacing}px
-                      </Text>
-                      <Slider
-                        value={labelSpacing}
-                        onChange={setLabelSpacing}
-                        min={0}
-                        max={100}
-                        step={5}
-                        marks={[
-                          { value: 0, label: "0" },
-                          { value: 50, label: "50" },
-                          { value: 100, label: "100" },
-                        ]}
-                      />
-                    </Stack>
-                    <Text size="xs" c="dimmed">
-                      Selected: {selectedTranscripts.length} gene(s)
-                    </Text>
+                    {selectedTranscripts.length >= 2 && (
+                      <Stack gap="xs" pb="md">
+                        <Text size="sm" fw={500}>
+                          Gene spacing: {geneSpacing}px
+                        </Text>
+                        <Slider
+                          value={geneSpacing}
+                          onChange={setGeneSpacing}
+                          min={10}
+                          max={200}
+                          step={5}
+                          marks={[
+                            { value: 10, label: "10" },
+                            { value: 100, label: "100" },
+                            { value: 200, label: "200" },
+                          ]}
+                        />
+                      </Stack>
+                    )}
+                    {showLabels && (
+                      <Stack gap="xs" pb="md">
+                        <Text size="sm" fw={500}>
+                          Label spacing: {labelSpacing}px
+                        </Text>
+                        <Slider
+                          value={labelSpacing}
+                          onChange={setLabelSpacing}
+                          min={0}
+                          max={100}
+                          step={5}
+                          marks={[
+                            { value: 0, label: "0" },
+                            { value: 50, label: "50" },
+                            { value: 100, label: "100" },
+                          ]}
+                        />
+                      </Stack>
+                    )}
                   </Stack>
                 </Card>
 


### PR DESCRIPTION
## Summary
- Multi-Gene SettingsをDisplay Optionsに名称変更
- Gene spacingを2遺伝子以上選択時のみ表示するよう条件追加
- Label spacingをShow gene labelsがオンのときのみ表示するよう条件追加
- Selected gene(s)の冗長な表記を削除
- Sliderのmarksラベル用にpadding-bottomを追加

## Test plan
- [ ] 1遺伝子選択時にGene spacingが非表示になることを確認
- [ ] 2遺伝子以上選択時にGene spacingが表示されることを確認
- [ ] Show gene labelsオフ時にLabel spacingが非表示になることを確認
- [ ] Sliderのmarksラベルがカード内に収まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)