### PR TITLE
Upgrade orval to version 8.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "@types/react-svg-pan-zoom": "^3.3.9",
-        "orval": "^8.0.2"
+        "orval": "^8.0.3"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1457,29 +1457,29 @@
       }
     },
     "node_modules/@orval/angular": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/angular/-/angular-8.0.2.tgz",
-      "integrity": "sha512-4RWMlGOFvsBrIPVZOo6fIRN46aMatgLpX69Zu9JeW/+9uQJ5CyNOtDg4RPYWVYdTFGjhEhf6OkeR0aKoxStAfA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/angular/-/angular-8.0.3.tgz",
+      "integrity": "sha512-zZyHVunumuxWUQMeNgFSCMKyBGIG1NWqlcctMpfecOYo2MbMaU6WeNws7BcfTXV6EP5gNbVdOjSdZ5N/6iX/kQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2"
+        "@orval/core": "8.0.3"
       }
     },
     "node_modules/@orval/axios": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/axios/-/axios-8.0.2.tgz",
-      "integrity": "sha512-C9Jt0+fc6EmhIhCXosUXffo55QG9FflGEAFw7J7G0w7gGxUHbUkPCSR6tXuH/Y72CRXiBdxlIpBs8UgzgyRf6Q==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/axios/-/axios-8.0.3.tgz",
+      "integrity": "sha512-Cb++1weUwvJ6fJFsMBzqVxUfw9EoyCa0kPieqQ0DDzzzfKWejhmSMlwVsIzQciQZs+W8rGzgg4NCPEMZpkQlqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2"
+        "@orval/core": "8.0.3"
       }
     },
     "node_modules/@orval/core": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/core/-/core-8.0.2.tgz",
-      "integrity": "sha512-XBKaEE2g378Y2Hs6LY/QZ5uVpffzsmHQR5Uvzr9K13Wb4LDbN3MR5VNWyISnLVAwdLDYyvqtGEcGpJJgsUH4EQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/core/-/core-8.0.3.tgz",
+      "integrity": "sha512-0UmTR06J4cijFsaKwZ7osC4dbEyghg3OzuMNnkkPGMkObIO3VkIn39loKNz02s0WFEaujycMFfTOhjq7CQF3aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1994,60 +1994,60 @@
       }
     },
     "node_modules/@orval/fetch": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-8.0.2.tgz",
-      "integrity": "sha512-rJdsYMxP3Q7XFzZ7stPkj31oPxWnXSFUONYxnDnDe8u95lQhtr0ThAKCuJg18Tc3ZlNpkvnufXqMkAKH8cOm1Q==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-8.0.3.tgz",
+      "integrity": "sha512-VXAcekE7OpmcIVXxfVSRl4VSOgQIKCsNjlOcrP6tuQii88WlGraOmP3dKRzpzeChlni2alU+1ABgoyQjJ74k+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2",
+        "@orval/core": "8.0.3",
         "@scalar/openapi-types": "0.5.3"
       }
     },
     "node_modules/@orval/hono": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/hono/-/hono-8.0.2.tgz",
-      "integrity": "sha512-P2dxi5MbTNyqQQSxteqa+K0hGTpW4rbxb8GuMaf+ConSucWhknJyhfVe3Q5cvRXodnpRrw801P5HDpwqXsVjAg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/hono/-/hono-8.0.3.tgz",
+      "integrity": "sha512-eYHgKfaVKDR4pFmLXFmVgB0R+Wf4xgMWrvrGbtLRnwgLfnVn+ewlaXDwhgiKvt7KohIqHIGw+9GD4tzGFp/QOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2",
-        "@orval/zod": "8.0.2",
+        "@orval/core": "8.0.3",
+        "@orval/zod": "8.0.3",
         "fs-extra": "^11.3.2",
         "remeda": "^2.32.0"
       }
     },
     "node_modules/@orval/mcp": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-8.0.2.tgz",
-      "integrity": "sha512-0asnmvWGbnIiP9mFB0QJ+gFAQfDup+/vjzybPJyTHAOuSfJUKLZIpj7JZpUPbgiSikzAXPLz0Jwna+T4q8ytpg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-8.0.3.tgz",
+      "integrity": "sha512-0ucpqUHgtHSSLKmqlGzlFHs9sUV+gK93vGMtMy2hLz6TXQqVRBulWB9KDC7vcurAw6jn09X/6No54bHNAKCY3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2",
-        "@orval/fetch": "8.0.2",
-        "@orval/zod": "8.0.2"
+        "@orval/core": "8.0.3",
+        "@orval/fetch": "8.0.3",
+        "@orval/zod": "8.0.3"
       }
     },
     "node_modules/@orval/mock": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/mock/-/mock-8.0.2.tgz",
-      "integrity": "sha512-eDo91SxlKgoStBcXRS/2kb0aO95xopq8/SAncHz7eKGI3TBHbE51D+FR04uBlbq5DuW31KEzb237uaZje5eVPg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/mock/-/mock-8.0.3.tgz",
+      "integrity": "sha512-X62XNsfKySBUifm+/x6kyPA97RSr3HgBn0HCFvNdgdUE5o/lR8izgnBwHjafmlHCh8dHXWQZGtSjM/lkj5so+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2"
+        "@orval/core": "8.0.3"
       }
     },
     "node_modules/@orval/query": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/query/-/query-8.0.2.tgz",
-      "integrity": "sha512-rO+1eKwaWcp0hOA/aez+e2X3f/bVGB1LRakfNaCsqRhhWfi0xeM1QsnIP1BazmZKjGJmsXZDrzHAnkWbIt5aUQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/query/-/query-8.0.3.tgz",
+      "integrity": "sha512-jai3fZMy40BJ8xb+q4kxSEmn48SfHrY9VWLIOFKb3hE+5aEhiNxcNiPuNX4TeZfWkaLAEUBfI3if2XHJ5emTTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2",
-        "@orval/fetch": "8.0.2",
+        "@orval/core": "8.0.3",
+        "@orval/fetch": "8.0.3",
         "chalk": "^5.6.2",
         "remeda": "^2.32.0"
       }
@@ -2066,34 +2066,34 @@
       }
     },
     "node_modules/@orval/solid-start": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/solid-start/-/solid-start-8.0.2.tgz",
-      "integrity": "sha512-Ihho1Haqb/z0blAk/IF87iDvi2BFntbGO+MNOeXXR9YUipYtIQtpfKogBVuSYCErmYQ7r6UUcKtc4s5tdHEfOA==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/solid-start/-/solid-start-8.0.3.tgz",
+      "integrity": "sha512-UC9vVcVy4skAzh9WwwBZFjHubVutb5O7urvcIJuBxIy6SGcVd11goVRfw0HYSfhQONiAhTOAUsRB5hQfIiN0lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2"
+        "@orval/core": "8.0.3"
       }
     },
     "node_modules/@orval/swr": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/swr/-/swr-8.0.2.tgz",
-      "integrity": "sha512-H43aOnede3ePPa5YNSLvdmfzHW1HX9LJ0vSMlGj4SQ4QrxRvTfyA03Mk8YQgq5IK/UofubXYEcYrXxQhK5t8Lg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/swr/-/swr-8.0.3.tgz",
+      "integrity": "sha512-sFlJLf/0/Kt6NAnUTAwMLLWma5GsbbYOftL+abStHMRDzv0qP3OFReek3fz3ZGVi3mENSKWAO9EVwC1FKZ681w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2",
-        "@orval/fetch": "8.0.2"
+        "@orval/core": "8.0.3",
+        "@orval/fetch": "8.0.3"
       }
     },
     "node_modules/@orval/zod": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@orval/zod/-/zod-8.0.2.tgz",
-      "integrity": "sha512-RP+GhsEtXXgteldZAkNt8DhSS37/6IPFr30Hg67YEnxMGgVOWIOjS8R2vHkw7uZEY7E7ZJlieiJh9Tav7Qii6g==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@orval/zod/-/zod-8.0.3.tgz",
+      "integrity": "sha512-mbnFvKp1HPwR9bopQiAlH3GGo9qlwFr4iwWH2zvmLjtRpP1t7Hox0/w94Yn0++HbtXf6jctm/lMUOS2F8C4eQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.2",
+        "@orval/core": "8.0.3",
         "remeda": "^2.32.0"
       }
     },
@@ -4555,24 +4555,24 @@
       }
     },
     "node_modules/orval": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/orval/-/orval-8.0.2.tgz",
-      "integrity": "sha512-0MPpNARaTNvE+hXkQC1YT3Os8pkId8B3i07cqn6OksNYfH8f9FYOHHbUSQUyEiOzovfSYIsmcum2pWbA9d4I0A==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/orval/-/orval-8.0.3.tgz",
+      "integrity": "sha512-L8RNV8aeCHy7qDI9Q3TlBIn+lCrCrqs+h83cHhuwz2otsOpDuT2J9BtkS8LxxTJrbjHFvwXbnkdKSfwWezxv3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
-        "@orval/angular": "8.0.2",
-        "@orval/axios": "8.0.2",
-        "@orval/core": "8.0.2",
-        "@orval/fetch": "8.0.2",
-        "@orval/hono": "8.0.2",
-        "@orval/mcp": "8.0.2",
-        "@orval/mock": "8.0.2",
-        "@orval/query": "8.0.2",
-        "@orval/solid-start": "8.0.2",
-        "@orval/swr": "8.0.2",
-        "@orval/zod": "8.0.2",
+        "@orval/angular": "8.0.3",
+        "@orval/axios": "8.0.3",
+        "@orval/core": "8.0.3",
+        "@orval/fetch": "8.0.3",
+        "@orval/hono": "8.0.3",
+        "@orval/mcp": "8.0.3",
+        "@orval/mock": "8.0.3",
+        "@orval/query": "8.0.3",
+        "@orval/solid-start": "8.0.3",
+        "@orval/swr": "8.0.3",
+        "@orval/zod": "8.0.3",
         "@scalar/json-magic": "^0.8.8",
         "@scalar/openapi-parser": "^0.23.9",
         "@scalar/openapi-types": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@types/react-svg-pan-zoom": "^3.3.9",
-    "orval": "^8.0.2"
+    "orval": "^8.0.3"
   }
 }


### PR DESCRIPTION
## Summary
This pull request upgrades the `orval` package and all its related sub-packages from version 8.0.2 to 8.0.3.

## Changes
- Updated `orval` main package from 8.0.2 to 8.0.3
- Updated all `@orval/*` sub-packages to 8.0.3:
  - @orval/angular
  - @orval/axios
  - @orval/core
  - @orval/fetch
  - @orval/hono
  - @orval/mcp
  - @orval/mock
  - @orval/query
  - @orval/solid-start
  - @orval/swr
  - @orval/zod

## Details
This is a patch version update that includes bug fixes and improvements to the orval code generation tool. All dependency versions have been synchronized to ensure compatibility across the orval ecosystem.