### PR TITLE
Upgrade python-multipart from 0.0.18 to 0.0.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.6
 reportlab==4.0.9
 numpy==1.26.4
-python-multipart==0.0.18
+python-multipart==0.0.22
 pydantic==2.6.3
 svgwrite==1.4.3


### PR DESCRIPTION
## Summary
Updates the `python-multipart` dependency to version 0.0.22, bringing in bug fixes and improvements from the latest stable release.

## Changes
- Bumped `python-multipart` from 0.0.18 to 0.0.22 in requirements.txt

## Details
This is a minor version update that includes:
- Bug fixes and stability improvements in multipart form data handling
- Better compatibility with FastAPI and uvicorn
- No breaking changes expected for existing functionality

The update maintains compatibility with the other pinned dependencies in the project.

https://claude.ai/code/session_01SNN3fDmn6hnvpV2bDzfMCA