### PR TITLE
Upgrade orval from 8.0.3 to 8.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "@types/react-svg-pan-zoom": "^3.3.9",
-        "orval": "^8.0.3"
+        "orval": "^8.2.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1457,29 +1457,29 @@
       }
     },
     "node_modules/@orval/angular": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/angular/-/angular-8.0.3.tgz",
-      "integrity": "sha512-zZyHVunumuxWUQMeNgFSCMKyBGIG1NWqlcctMpfecOYo2MbMaU6WeNws7BcfTXV6EP5gNbVdOjSdZ5N/6iX/kQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/angular/-/angular-8.2.0.tgz",
+      "integrity": "sha512-M7Y8MHd8lkhmqXrwtN9A7qWLw4ec0PovlPpZuffe5wHA/dl1PCN4fVTVOqAG8TFD+Xml/r9yl2yVgvg6osK2Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3"
+        "@orval/core": "8.2.0"
       }
     },
     "node_modules/@orval/axios": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/axios/-/axios-8.0.3.tgz",
-      "integrity": "sha512-Cb++1weUwvJ6fJFsMBzqVxUfw9EoyCa0kPieqQ0DDzzzfKWejhmSMlwVsIzQciQZs+W8rGzgg4NCPEMZpkQlqw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/axios/-/axios-8.2.0.tgz",
+      "integrity": "sha512-aR/5DKE06FWZd9LV9vvPdxVkbu1oGwfPRn3smAfUiZSFFf8CYI8eFcA33Ihazyh0z0Y7FNsk0nXtTvlfPIgx0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3"
+        "@orval/core": "8.2.0"
       }
     },
     "node_modules/@orval/core": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/core/-/core-8.0.3.tgz",
-      "integrity": "sha512-0UmTR06J4cijFsaKwZ7osC4dbEyghg3OzuMNnkkPGMkObIO3VkIn39loKNz02s0WFEaujycMFfTOhjq7CQF3aQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/core/-/core-8.2.0.tgz",
+      "integrity": "sha512-opnmNg03nZJ6rXGyMDJJ2UrsrMpINYHcJQIeCH+7WV8IHn8nBtgC7fZBeFpFkw2yK8cLyP7h+q5TDy8rkPEYPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1994,60 +1994,60 @@
       }
     },
     "node_modules/@orval/fetch": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-8.0.3.tgz",
-      "integrity": "sha512-VXAcekE7OpmcIVXxfVSRl4VSOgQIKCsNjlOcrP6tuQii88WlGraOmP3dKRzpzeChlni2alU+1ABgoyQjJ74k+w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-8.2.0.tgz",
+      "integrity": "sha512-dY82yR3z5QP4m4HGKiROf7p263D31nCIUPm4HCj1mpN6ua6gDEcqvjlvuclcOLd2x0DpG0NESq+ujZvQ3m2GGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3",
+        "@orval/core": "8.2.0",
         "@scalar/openapi-types": "0.5.3"
       }
     },
     "node_modules/@orval/hono": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/hono/-/hono-8.0.3.tgz",
-      "integrity": "sha512-eYHgKfaVKDR4pFmLXFmVgB0R+Wf4xgMWrvrGbtLRnwgLfnVn+ewlaXDwhgiKvt7KohIqHIGw+9GD4tzGFp/QOg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/hono/-/hono-8.2.0.tgz",
+      "integrity": "sha512-qRZtQMwrZ/dQRPcYfG9L3EW0q1Tc3BGjPDFF/EPTbuxOAxYvIB/Jgq3KBVImHyuGdwmiJiBH1px7EIcfki1YbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3",
-        "@orval/zod": "8.0.3",
+        "@orval/core": "8.2.0",
+        "@orval/zod": "8.2.0",
         "fs-extra": "^11.3.2",
         "remeda": "^2.32.0"
       }
     },
     "node_modules/@orval/mcp": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-8.0.3.tgz",
-      "integrity": "sha512-0ucpqUHgtHSSLKmqlGzlFHs9sUV+gK93vGMtMy2hLz6TXQqVRBulWB9KDC7vcurAw6jn09X/6No54bHNAKCY3A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-8.2.0.tgz",
+      "integrity": "sha512-n5jogm6/tJeZarGGHsnMxKPPLJkfYeSPFnZYOpR54UXt82KaEDqltqphTJLuKHpZLUkhmIxMRtUrhmpW7MWKEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3",
-        "@orval/fetch": "8.0.3",
-        "@orval/zod": "8.0.3"
+        "@orval/core": "8.2.0",
+        "@orval/fetch": "8.2.0",
+        "@orval/zod": "8.2.0"
       }
     },
     "node_modules/@orval/mock": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/mock/-/mock-8.0.3.tgz",
-      "integrity": "sha512-X62XNsfKySBUifm+/x6kyPA97RSr3HgBn0HCFvNdgdUE5o/lR8izgnBwHjafmlHCh8dHXWQZGtSjM/lkj5so+Q==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/mock/-/mock-8.2.0.tgz",
+      "integrity": "sha512-eJuPvKZnV6Ty89i/ab0gWiWE0LS2Xtu+M+67+3PBTi/PqpxI9jsYeIWlNnv8mhOmtMhZ9z/FRxydjfODKeGK+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3"
+        "@orval/core": "8.2.0"
       }
     },
     "node_modules/@orval/query": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/query/-/query-8.0.3.tgz",
-      "integrity": "sha512-jai3fZMy40BJ8xb+q4kxSEmn48SfHrY9VWLIOFKb3hE+5aEhiNxcNiPuNX4TeZfWkaLAEUBfI3if2XHJ5emTTA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/query/-/query-8.2.0.tgz",
+      "integrity": "sha512-9/y55gKm1mF+BKZBetKowCcJrnz5HrcDlHOtnf2rZJjepQ73vgsOOnLviVxUrJf4w5Yxb4MPbgzL8KklOzhYPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3",
-        "@orval/fetch": "8.0.3",
+        "@orval/core": "8.2.0",
+        "@orval/fetch": "8.2.0",
         "chalk": "^5.6.2",
         "remeda": "^2.32.0"
       }
@@ -2066,34 +2066,34 @@
       }
     },
     "node_modules/@orval/solid-start": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/solid-start/-/solid-start-8.0.3.tgz",
-      "integrity": "sha512-UC9vVcVy4skAzh9WwwBZFjHubVutb5O7urvcIJuBxIy6SGcVd11goVRfw0HYSfhQONiAhTOAUsRB5hQfIiN0lw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/solid-start/-/solid-start-8.2.0.tgz",
+      "integrity": "sha512-FPxEC4cMi3VIMBb3lcuI33VrRug+PHREI5QMA6TqKULGfc07OtStKZaRXLugIP8Dxkkn+YU+xSZgE58/bG77Qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3"
+        "@orval/core": "8.2.0"
       }
     },
     "node_modules/@orval/swr": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/swr/-/swr-8.0.3.tgz",
-      "integrity": "sha512-sFlJLf/0/Kt6NAnUTAwMLLWma5GsbbYOftL+abStHMRDzv0qP3OFReek3fz3ZGVi3mENSKWAO9EVwC1FKZ681w==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/swr/-/swr-8.2.0.tgz",
+      "integrity": "sha512-CSvhQAWv/MD2MeF6ewfgMCIB1NB1neSnpo/iVxehodPnM0tWqf0+xSdUWktSofLbJa900Si/XRbmywa9wLd3Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3",
-        "@orval/fetch": "8.0.3"
+        "@orval/core": "8.2.0",
+        "@orval/fetch": "8.2.0"
       }
     },
     "node_modules/@orval/zod": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@orval/zod/-/zod-8.0.3.tgz",
-      "integrity": "sha512-mbnFvKp1HPwR9bopQiAlH3GGo9qlwFr4iwWH2zvmLjtRpP1t7Hox0/w94Yn0++HbtXf6jctm/lMUOS2F8C4eQA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@orval/zod/-/zod-8.2.0.tgz",
+      "integrity": "sha512-r710+ZNxl4AHiIuyh5/T1S3Gx/tGoA5b/ukWtRIsICNuSJpOd2o4Pct4CKWiBIn+Vyv4J0xN9hU2EZeRs0qXBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.0.3",
+        "@orval/core": "8.2.0",
         "remeda": "^2.32.0"
       }
     },
@@ -4555,24 +4555,24 @@
       }
     },
     "node_modules/orval": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/orval/-/orval-8.0.3.tgz",
-      "integrity": "sha512-L8RNV8aeCHy7qDI9Q3TlBIn+lCrCrqs+h83cHhuwz2otsOpDuT2J9BtkS8LxxTJrbjHFvwXbnkdKSfwWezxv3g==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/orval/-/orval-8.2.0.tgz",
+      "integrity": "sha512-1X/OUopJNvnOJKHbkdhrjChF2QPIRRLWMLXgnI42efS8ErNViassU2HLm/T27tgptbYxTxbAsiidcSrgRbrL0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
-        "@orval/angular": "8.0.3",
-        "@orval/axios": "8.0.3",
-        "@orval/core": "8.0.3",
-        "@orval/fetch": "8.0.3",
-        "@orval/hono": "8.0.3",
-        "@orval/mcp": "8.0.3",
-        "@orval/mock": "8.0.3",
-        "@orval/query": "8.0.3",
-        "@orval/solid-start": "8.0.3",
-        "@orval/swr": "8.0.3",
-        "@orval/zod": "8.0.3",
+        "@orval/angular": "8.2.0",
+        "@orval/axios": "8.2.0",
+        "@orval/core": "8.2.0",
+        "@orval/fetch": "8.2.0",
+        "@orval/hono": "8.2.0",
+        "@orval/mcp": "8.2.0",
+        "@orval/mock": "8.2.0",
+        "@orval/query": "8.2.0",
+        "@orval/solid-start": "8.2.0",
+        "@orval/swr": "8.2.0",
+        "@orval/zod": "8.2.0",
         "@scalar/json-magic": "^0.8.8",
         "@scalar/openapi-parser": "^0.23.9",
         "@scalar/openapi-types": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@types/react-svg-pan-zoom": "^3.3.9",
-    "orval": "^8.0.3"
+    "orval": "^8.2.0"
   }
 }


### PR DESCRIPTION
## Summary
This PR upgrades the `orval` code generation tool and all its related packages from version 8.0.3 to 8.2.0.

## Changes
- Updated `orval` package from `^8.0.3` to `^8.2.0` in package.json
- Updated all `@orval/*` scoped packages to version 8.2.0:
  - @orval/angular
  - @orval/axios
  - @orval/core
  - @orval/fetch
  - @orval/hono
  - @orval/mcp
  - @orval/mock
  - @orval/query
  - @orval/solid-start
  - @orval/swr
  - @orval/zod
- Updated package-lock.json with new resolved versions and integrity hashes

## Notes
This is a minor version bump that includes bug fixes and improvements to the orval code generation tool. All dependent packages have been updated to maintain consistency across the orval ecosystem.

https://claude.ai/code/session_01QU95hSsuEkPmHRdc8uo8PP