### PR TITLE
feat: GFF3/GTFパース時のエラーハンドリング改善とExample表示削除

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,6 @@
 import {
   Button,
   Card,
-  Code,
   ColorInput,
   Divider,
   Grid,
@@ -328,7 +327,10 @@ export default function Home() {
     } catch (error) {
       notifications.show({
         title: "Error",
-        message: `Error loading preset GFF file: ${error}`,
+        message:
+          error instanceof Error
+            ? error.message
+            : "プリセットGFFファイルの読み込み中にエラーが発生しました。",
         color: "red",
         autoClose: 5000,
       });
@@ -650,7 +652,10 @@ export default function Home() {
                     } catch (error) {
                       notifications.show({
                         title: "Error",
-                        message: `Error parsing file: ${error}`,
+                        message:
+                          error instanceof Error
+                            ? error.message
+                            : "ファイルの解析中に予期しないエラーが発生しました。",
                         color: "red",
                         autoClose: 5000,
                       });
@@ -698,19 +703,6 @@ export default function Home() {
                   </Stack>
                 </Group>
               </Dropzone>
-
-              <div style={{ marginTop: "1rem" }}>
-                <Text fw={500} mb="xs">
-                  Example GFF3 Format:
-                </Text>
-                <Code block p="md">
-                  {`##gff-version 3
-Chr1 TAIR10 gene 3631 5899 . + . ID=AT1G01010;Name=AT1G01010
-Chr1 TAIR10 mRNA 3631 5899 . + . ID=AT1G01010.1;Parent=AT1G01010
-Chr1 TAIR10 exon 3631 3913 . + . Parent=AT1G01010.1
-Chr1 TAIR10 exon 3996 4276 . + . Parent=AT1G01010.1`}
-                </Code>
-              </div>
             </Stack>
           </Card>
         </Stack>

--- a/app/utils/gtf.ts
+++ b/app/utils/gtf.ts
@@ -71,13 +71,36 @@ export function parseFileContent(
   content: string,
   fileName: string,
 ): GeneStructureInfo[] {
-  const format = detectFileFormat(fileName);
-  if (format === "gtf") {
-    return parseGtfString(content);
+  if (!content.trim()) {
+    throw new Error(
+      "ファイルが空です。GFF3またはGTF形式のファイルを選択してください。",
+    );
   }
-  const gff = parseStringSync(content);
-  const mRNAs = getmRNAs(gff);
-  return getGeneStructureInfo(mRNAs);
+
+  const format = detectFileFormat(fileName);
+
+  let result: GeneStructureInfo[];
+  if (format === "gtf") {
+    result = parseGtfString(content);
+  } else {
+    try {
+      const gff = parseStringSync(content);
+      const mRNAs = getmRNAs(gff);
+      result = getGeneStructureInfo(mRNAs);
+    } catch (e) {
+      throw new Error(
+        "GFF3ファイルの解析に失敗しました。ファイルがGFF3形式であることを確認してください。",
+      );
+    }
+  }
+
+  if (result.length === 0) {
+    throw new Error(
+      "mRNA/トランスクリプトが見つかりませんでした。ファイルにmRNAフィーチャーが含まれていることを確認してください。",
+    );
+  }
+
+  return result;
 }
 
 export function parseGtfString(content: string): GeneStructureInfo[] {


### PR DESCRIPTION
- Example GFF3 Format表示を削除してUIをシンプルに
- 空ファイル、パース失敗、mRNA未検出時にエラーメッセージを表示
- エラー通知メッセージを日本語で分かりやすく改善

https://claude.ai/code/session_01MmBBD1L9U6cEpSxgLymApM