### PR TITLE
feat: CLI版と同等の描画機能をWeb版に追加

### DIFF
--- a/api/color_utils.py
+++ b/api/color_utils.py
@@ -1,0 +1,20 @@
+# =====================
+# カラーユーティリティ関数
+# =====================
+
+
+def get_domain_color(domain_name, color_map, palette):
+    """
+    domain名ごとに一貫した色を返す
+
+    Args:
+        domain_name: ドメイン名
+        color_map: ドメイン名→色のマッピング辞書
+        palette: 色パレットリスト
+
+    Returns:
+        割り当てられた色
+    """
+    if domain_name not in color_map:
+        color_map[domain_name] = palette[len(color_map) % len(palette)]
+    return color_map[domain_name]

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,16 @@
+# =====================
+# ドメイン色パレット
+# =====================
+
+DOMAIN_COLOR_PALETTE = [
+    "lightblue",     # blue
+    "lightcoral",    # orange
+    "lightgreen",    # green
+    "#d62728",       # red
+    "#9467bd",       # purple
+    "#8c564b",       # brown
+    "#e377c2",       # pink
+    "#7f7f7f",       # gray
+    "#bcbd22",       # olive
+    "#17becf",       # cyan
+]

--- a/api/drawer.py
+++ b/api/drawer.py
@@ -76,6 +76,21 @@ def get_tick_params(range_size: int) -> tuple:
 # 描画関数
 # =====================
 
+def get_terminal_feature(features):
+    """
+    右端（最大 end）にある feature を返す。
+    優先順位: three_prime_UTR > CDS > exon
+    """
+    priority = ['three_prime_UTR', 'CDS', 'exon']
+
+    for ftype in priority:
+        candidates = [f for f in features if f.feature_type == ftype]
+        if candidates:
+            return max(candidates, key=lambda f: f.end)
+
+    return None
+
+
 def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_factor=30.0,
                         utr_color=None, exon_color=None, line_color=None, domain_color=None):
     # デフォルト色を設定
@@ -86,6 +101,7 @@ def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_
 
     min_start = gene.to_relative()
     all_features = gene.get_sorted_features()
+    terminal_feature = get_terminal_feature(all_features)
     max_end = max(f.end / shrink_factor for f in all_features)
 
     shift = -min_start if min_start < 0 else 0
@@ -108,14 +124,21 @@ def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_
             continue
 
         if feat.feature_type == 'deletion':
+            # くの字型の折れ線
+            y_line = y_pos + height_feature // 2
+            mid_x = x_start + (x_end - x_start) / 2
+            offset = 10  # くの字の高さ
             dwg.add(
-                dwg.rect(
-                    insert=(x_start, y_pos),
-                    size=(width, height_feature),
+                dwg.polyline(
+                    points=[
+                        (x_start, y_line),
+                        (mid_x, y_line - offset),
+                        (x_end, y_line)
+                    ],
                     fill='none',
-                    stroke='red',
-                    stroke_dasharray="5,5",
-                    stroke_width=2
+                    stroke='black',
+                    stroke_width=1,
+                    stroke_dasharray="2,2"
                 )
             )
         elif feat.feature_type in ('exon', 'CDS', 'five_prime_UTR', 'three_prime_UTR'):
@@ -129,15 +152,33 @@ def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_
             stroke_width = FEATURE_OUTLINE_WIDTHS.get(feat.feature_type, 1)
             outline_enabled = FEATURE_OUTLINE_ENABLED.get(feat.feature_type, True)
 
-            dwg.add(
-                dwg.rect(
-                    insert=(x_start, y_pos),
-                    size=(width, height_feature),
-                    fill=fill_color,
-                    stroke=stroke_color if outline_enabled else 'none',
-                    stroke_width=stroke_width
+            # Terminal Feature は矢印形状
+            if feat is terminal_feature:
+                tip = height_feature // 2
+                dwg.add(
+                    dwg.polygon(
+                        points=[
+                            (x_start, y_pos),
+                            (x_end - tip, y_pos),
+                            (x_end, y_pos + height_feature / 2),
+                            (x_end - tip, y_pos + height_feature),
+                            (x_start, y_pos + height_feature)
+                        ],
+                        fill=fill_color,
+                        stroke=stroke_color if outline_enabled else 'none',
+                        stroke_width=stroke_width
+                    )
                 )
-            )
+            else:
+                dwg.add(
+                    dwg.rect(
+                        insert=(x_start, y_pos),
+                        size=(width, height_feature),
+                        fill=fill_color,
+                        stroke=stroke_color if outline_enabled else 'none',
+                        stroke_width=stroke_width
+                    )
+                )
         elif feat.feature_type == 'intron':
             if x_start < x_end:
                 y_line = y_pos + height_feature // 2
@@ -150,45 +191,118 @@ def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_
                     )
                 )
 
+    # === Insertions ===
+    triangle_width = 8
+    triangle_height = 6
+    y_triangle = y_pos - 8  # exon の少し上
+
+    for ins_pos in getattr(gene, "insertions", []):
+        x = LEFT_MARGIN + (ins_pos / shrink_factor + shift / shrink_factor) * scale
+        dwg.add(
+            dwg.polygon(
+                points=[
+                    (x - triangle_width / 2, y_triangle),
+                    (x + triangle_width / 2, y_triangle),
+                    (x, y_triangle + triangle_height)
+                ],
+                fill="black",
+                stroke="black",
+                stroke_width=1.5
+            )
+        )
+
+    # === SNPs ===
+    snp_extend_up = 8
+    snp_extend_down = 8
+    y_snp_top = y_pos - snp_extend_up
+    y_snp_bottom = y_pos + height_feature + snp_extend_down
+
+    for snp_pos in getattr(gene, "snps", []):
+        x = LEFT_MARGIN + (snp_pos / shrink_factor + shift / shrink_factor) * scale
+        dwg.add(
+            dwg.line(
+                start=(x, y_snp_top),
+                end=(x, y_snp_bottom),
+                stroke="black",
+                stroke_width=1.2
+            )
+        )
+
+    # ドメインを描画（上層）
     for feat in all_features:
         if feat.feature_type == 'domain':
             x_start = LEFT_MARGIN + (feat.start / shrink_factor + shift / shrink_factor) * scale
             x_end = LEFT_MARGIN + (feat.end / shrink_factor + shift / shrink_factor) * scale
             width = x_end - x_start
 
+            # ドメイン色はattributesから取得
+            feat_domain_color = feat.attributes.get('color', domain_color)
+
             dwg.add(
                 dwg.rect(
                     insert=(x_start, y_pos),
                     size=(width, height_feature),
-                    fill=domain_color,
+                    fill=feat_domain_color,
                     stroke=FEATURE_OUTLINES.get('domain', 'black'),
                     stroke_width=FEATURE_OUTLINE_WIDTHS.get('domain', 1)
                 )
             )
 
-    # === 凡例 ===
+    # === 凡例の動的生成 ===
+    present_feature_types = set(f.feature_type for f in all_features)
+    legend_items = []
+
+    if 'CDS' in present_feature_types or 'exon' in present_feature_types:
+        legend_items.append(('CDS', 'Exon/CDS', exon_color))
+    if 'five_prime_UTR' in present_feature_types:
+        legend_items.append(('five_prime_UTR', "5' UTR", utr_color))
+    if 'three_prime_UTR' in present_feature_types:
+        legend_items.append(('three_prime_UTR', "3' UTR", utr_color))
+    if 'intron' in present_feature_types:
+        legend_items.append(('intron', 'Intron', line_color))
+    if 'deletion' in present_feature_types:
+        legend_items.append(('deletion', 'Deletion', None))
+    if getattr(gene, "insertions", []):
+        legend_items.append(('insertion', 'Insertion', None))
+    if getattr(gene, "snps", []):
+        legend_items.append(('snp', 'SNP', None))
+    # ドメインは名前ごとに個別表示
+    for domain_name, color in getattr(gene, 'domain_color_map', {}).items():
+        legend_items.append(('domain', domain_name, color))
+
     legend_x = max_x_coord + 100
     legend_y = 30
     box_size = 12
     spacing = 20
-    legend_items = [
-        ('domain', 'Domain', domain_color),
-        ('CDS', 'Exon/CDS', exon_color),
-        ('five_prime_UTR', "5' UTR", utr_color),
-        ('three_prime_UTR', "3' UTR", utr_color),
-        ('intron', 'Intron', line_color),
-        ('deletion', 'Deletion', None)
-    ]
+
     for i, (feat_key, label, color) in enumerate(legend_items):
         y_legend = legend_y + i * spacing
         if feat_key == 'deletion':
-            dwg.add(dwg.rect(
-                insert=(legend_x, y_legend),
-                size=(box_size, box_size),
+            # くの字型
+            y_mid = y_legend + box_size // 2
+            dwg.add(dwg.polyline(
+                points=[(legend_x, y_mid), (legend_x + box_size // 2, y_mid - 6), (legend_x + box_size, y_mid)],
                 fill='none',
-                stroke='red',
-                stroke_dasharray="5,5",
-                stroke_width=2
+                stroke='black',
+                stroke_width=1.5,
+                stroke_dasharray="2,2"
+            ))
+        elif feat_key == 'insertion':
+            # 逆三角形
+            y_mid = y_legend + box_size // 2
+            dwg.add(dwg.polygon(
+                points=[(legend_x, y_mid - 4), (legend_x + box_size, y_mid - 4), (legend_x + box_size // 2, y_mid + 4)],
+                fill='black',
+                stroke='black',
+                stroke_width=1.5
+            ))
+        elif feat_key == 'snp':
+            # 縦線
+            dwg.add(dwg.line(
+                start=(legend_x + box_size // 2, y_legend),
+                end=(legend_x + box_size // 2, y_legend + box_size),
+                stroke='black',
+                stroke_width=1.2
             ))
         elif feat_key == 'intron':
             y_line = y_legend + box_size // 2
@@ -294,6 +408,7 @@ def draw_multiple_gene_structures(
     for idx, (gene, label) in enumerate(zip(genes, labels)):
         all_features, shift, max_end = gene_data[idx]
         y_pos = top_margin + idx * (gene_height + gene_spacing)
+        terminal_feature = get_terminal_feature(all_features)
 
         # ラベルを描画
         if show_labels:
@@ -315,14 +430,21 @@ def draw_multiple_gene_structures(
                 continue
 
             if feat.feature_type == 'deletion':
+                # くの字型の折れ線
+                y_line = y_pos + height_feature // 2
+                mid_x = x_start + (x_end - x_start) / 2
+                offset = 10
                 dwg.add(
-                    dwg.rect(
-                        insert=(x_start, y_pos),
-                        size=(width, height_feature),
+                    dwg.polyline(
+                        points=[
+                            (x_start, y_line),
+                            (mid_x, y_line - offset),
+                            (x_end, y_line)
+                        ],
                         fill='none',
-                        stroke='red',
-                        stroke_dasharray="5,5",
-                        stroke_width=2
+                        stroke='black',
+                        stroke_width=1,
+                        stroke_dasharray="2,2"
                     )
                 )
             elif feat.feature_type in ('exon', 'CDS', 'five_prime_UTR', 'three_prime_UTR'):
@@ -335,15 +457,33 @@ def draw_multiple_gene_structures(
                 stroke_width = FEATURE_OUTLINE_WIDTHS.get(feat.feature_type, 1)
                 outline_enabled = FEATURE_OUTLINE_ENABLED.get(feat.feature_type, True)
 
-                dwg.add(
-                    dwg.rect(
-                        insert=(x_start, y_pos),
-                        size=(width, height_feature),
-                        fill=fill_color,
-                        stroke=stroke_color if outline_enabled else 'none',
-                        stroke_width=stroke_width
+                # Terminal Feature は矢印形状
+                if feat is terminal_feature:
+                    tip = height_feature // 2
+                    dwg.add(
+                        dwg.polygon(
+                            points=[
+                                (x_start, y_pos),
+                                (x_end - tip, y_pos),
+                                (x_end, y_pos + height_feature / 2),
+                                (x_end - tip, y_pos + height_feature),
+                                (x_start, y_pos + height_feature)
+                            ],
+                            fill=fill_color,
+                            stroke=stroke_color if outline_enabled else 'none',
+                            stroke_width=stroke_width
+                        )
                     )
-                )
+                else:
+                    dwg.add(
+                        dwg.rect(
+                            insert=(x_start, y_pos),
+                            size=(width, height_feature),
+                            fill=fill_color,
+                            stroke=stroke_color if outline_enabled else 'none',
+                            stroke_width=stroke_width
+                        )
+                    )
             elif feat.feature_type == 'intron':
                 if x_start < x_end:
                     y_line = y_pos + height_feature // 2
@@ -356,6 +496,43 @@ def draw_multiple_gene_structures(
                         )
                     )
 
+        # === Insertions ===
+        triangle_width = 8
+        triangle_height = 6
+        y_triangle = y_pos - 8
+
+        for ins_pos in getattr(gene, "insertions", []):
+            x = LEFT_MARGIN + label_width + (ins_pos / shrink_factor + shift / shrink_factor) * scale
+            dwg.add(
+                dwg.polygon(
+                    points=[
+                        (x - triangle_width / 2, y_triangle),
+                        (x + triangle_width / 2, y_triangle),
+                        (x, y_triangle + triangle_height)
+                    ],
+                    fill="black",
+                    stroke="black",
+                    stroke_width=1.5
+                )
+            )
+
+        # === SNPs ===
+        snp_extend_up = 8
+        snp_extend_down = 8
+        y_snp_top = y_pos - snp_extend_up
+        y_snp_bottom = y_pos + height_feature + snp_extend_down
+
+        for snp_pos in getattr(gene, "snps", []):
+            x = LEFT_MARGIN + label_width + (snp_pos / shrink_factor + shift / shrink_factor) * scale
+            dwg.add(
+                dwg.line(
+                    start=(x, y_snp_top),
+                    end=(x, y_snp_bottom),
+                    stroke="black",
+                    stroke_width=1.2
+                )
+            )
+
         # ドメインを描画（上層）
         for feat in all_features:
             if feat.feature_type == 'domain':
@@ -363,39 +540,87 @@ def draw_multiple_gene_structures(
                 x_end = LEFT_MARGIN + label_width + (feat.end / shrink_factor + shift / shrink_factor) * scale
                 width = x_end - x_start
 
+                # ドメイン色はattributesから取得
+                feat_domain_color = feat.attributes.get('color', domain_color)
+
                 dwg.add(
                     dwg.rect(
                         insert=(x_start, y_pos),
                         size=(width, height_feature),
-                        fill=domain_color,
+                        fill=feat_domain_color,
                         stroke=FEATURE_OUTLINES.get('domain', 'black'),
                         stroke_width=FEATURE_OUTLINE_WIDTHS.get('domain', 1)
                     )
                 )
 
-    # === 凡例（右上に1つだけ配置） ===
+    # === 凡例の動的生成 ===
+    # 全遺伝子のfeature typeを収集
+    all_feature_types = set()
+    all_domain_colors = {}
+    has_insertions = False
+    has_snps = False
+    for gene in genes:
+        for f in gene.get_sorted_features():
+            all_feature_types.add(f.feature_type)
+        all_domain_colors.update(getattr(gene, 'domain_color_map', {}))
+        if getattr(gene, "insertions", []):
+            has_insertions = True
+        if getattr(gene, "snps", []):
+            has_snps = True
+
+    # 凡例アイテムを動的に構築
+    legend_items = []
+    if 'CDS' in all_feature_types or 'exon' in all_feature_types:
+        legend_items.append(('CDS', 'Exon/CDS', exon_color))
+    if 'five_prime_UTR' in all_feature_types:
+        legend_items.append(('five_prime_UTR', "5' UTR", utr_color))
+    if 'three_prime_UTR' in all_feature_types:
+        legend_items.append(('three_prime_UTR', "3' UTR", utr_color))
+    if 'intron' in all_feature_types:
+        legend_items.append(('intron', 'Intron', line_color))
+    if 'deletion' in all_feature_types:
+        legend_items.append(('deletion', 'Deletion', None))
+    if has_insertions:
+        legend_items.append(('insertion', 'Insertion', None))
+    if has_snps:
+        legend_items.append(('snp', 'SNP', None))
+    # ドメインは名前ごとに個別表示
+    for domain_name, color in all_domain_colors.items():
+        legend_items.append(('domain', domain_name, color))
+
     legend_x = global_max_x + 50
     legend_y = 30
     box_size = 12
     spacing = 20
-    legend_items = [
-        ('domain', 'Domain', domain_color),
-        ('CDS', 'Exon/CDS', exon_color),
-        ('five_prime_UTR', "5' UTR", utr_color),
-        ('three_prime_UTR', "3' UTR", utr_color),
-        ('intron', 'Intron', line_color),
-        ('deletion', 'Deletion', None)
-    ]
+
     for i, (feat_key, label_text, color) in enumerate(legend_items):
         y_legend = legend_y + i * spacing
         if feat_key == 'deletion':
-            dwg.add(dwg.rect(
-                insert=(legend_x, y_legend),
-                size=(box_size, box_size),
+            # くの字型
+            y_mid = y_legend + box_size // 2
+            dwg.add(dwg.polyline(
+                points=[(legend_x, y_mid), (legend_x + box_size // 2, y_mid - 6), (legend_x + box_size, y_mid)],
                 fill='none',
-                stroke='red',
-                stroke_dasharray="5,5",
-                stroke_width=2
+                stroke='black',
+                stroke_width=1.5,
+                stroke_dasharray="2,2"
+            ))
+        elif feat_key == 'insertion':
+            # 逆三角形
+            y_mid = y_legend + box_size // 2
+            dwg.add(dwg.polygon(
+                points=[(legend_x, y_mid - 4), (legend_x + box_size, y_mid - 4), (legend_x + box_size // 2, y_mid + 4)],
+                fill='black',
+                stroke='black',
+                stroke_width=1.5
+            ))
+        elif feat_key == 'snp':
+            # 縦線
+            dwg.add(dwg.line(
+                start=(legend_x + box_size // 2, y_legend),
+                end=(legend_x + box_size // 2, y_legend + box_size),
+                stroke='black',
+                stroke_width=1.2
             ))
         elif feat_key == 'intron':
             y_line = y_legend + box_size // 2
@@ -586,6 +811,7 @@ def draw_region_gene_structures(
         label = gene_info['label']
         all_features = gene.get_sorted_features()
         y_pos = top_margin + track_idx * (track_height + gene_spacing)
+        terminal_feature = get_terminal_feature(all_features)
 
         # 遺伝子の中心X座標を計算（ラベル配置用）
         gene_center_x = None
@@ -605,14 +831,21 @@ def draw_region_gene_structures(
                 continue
 
             if feat.feature_type == 'deletion':
+                # くの字型の折れ線
+                y_line = y_pos + height_feature // 2
+                mid_x = x_start + (x_end - x_start) / 2
+                offset = 10
                 dwg.add(
-                    dwg.rect(
-                        insert=(x_start, y_pos),
-                        size=(width, height_feature),
+                    dwg.polyline(
+                        points=[
+                            (x_start, y_line),
+                            (mid_x, y_line - offset),
+                            (x_end, y_line)
+                        ],
                         fill='none',
-                        stroke='red',
-                        stroke_dasharray="5,5",
-                        stroke_width=2
+                        stroke='black',
+                        stroke_width=1,
+                        stroke_dasharray="2,2"
                     )
                 )
             elif feat.feature_type in ('exon', 'CDS', 'five_prime_UTR', 'three_prime_UTR'):
@@ -625,15 +858,33 @@ def draw_region_gene_structures(
                 stroke_width = FEATURE_OUTLINE_WIDTHS.get(feat.feature_type, 1)
                 outline_enabled = FEATURE_OUTLINE_ENABLED.get(feat.feature_type, True)
 
-                dwg.add(
-                    dwg.rect(
-                        insert=(x_start, y_pos),
-                        size=(width, height_feature),
-                        fill=fill_color,
-                        stroke=stroke_color if outline_enabled else 'none',
-                        stroke_width=stroke_width
+                # Terminal Feature は矢印形状
+                if feat is terminal_feature:
+                    tip = height_feature // 2
+                    dwg.add(
+                        dwg.polygon(
+                            points=[
+                                (x_start, y_pos),
+                                (x_end - tip, y_pos),
+                                (x_end, y_pos + height_feature / 2),
+                                (x_end - tip, y_pos + height_feature),
+                                (x_start, y_pos + height_feature)
+                            ],
+                            fill=fill_color,
+                            stroke=stroke_color if outline_enabled else 'none',
+                            stroke_width=stroke_width
+                        )
                     )
-                )
+                else:
+                    dwg.add(
+                        dwg.rect(
+                            insert=(x_start, y_pos),
+                            size=(width, height_feature),
+                            fill=fill_color,
+                            stroke=stroke_color if outline_enabled else 'none',
+                            stroke_width=stroke_width
+                        )
+                    )
             elif feat.feature_type == 'intron':
                 if x_start < x_end:
                     y_line = y_pos + height_feature // 2
@@ -646,6 +897,43 @@ def draw_region_gene_structures(
                         )
                     )
 
+        # === Insertions ===
+        triangle_width = 8
+        triangle_height = 6
+        y_triangle = y_pos - 8
+
+        for ins_pos in getattr(gene, "insertions", []):
+            x = LEFT_MARGIN + (ins_pos - draw_start) / shrink_factor * scale
+            dwg.add(
+                dwg.polygon(
+                    points=[
+                        (x - triangle_width / 2, y_triangle),
+                        (x + triangle_width / 2, y_triangle),
+                        (x, y_triangle + triangle_height)
+                    ],
+                    fill="black",
+                    stroke="black",
+                    stroke_width=1.5
+                )
+            )
+
+        # === SNPs ===
+        snp_extend_up = 8
+        snp_extend_down = 8
+        y_snp_top = y_pos - snp_extend_up
+        y_snp_bottom = y_pos + height_feature + snp_extend_down
+
+        for snp_pos in getattr(gene, "snps", []):
+            x = LEFT_MARGIN + (snp_pos - draw_start) / shrink_factor * scale
+            dwg.add(
+                dwg.line(
+                    start=(x, y_snp_top),
+                    end=(x, y_snp_bottom),
+                    stroke="black",
+                    stroke_width=1.2
+                )
+            )
+
         # ドメインを描画（上層）
         for feat in all_features:
             if feat.feature_type == 'domain':
@@ -653,11 +941,14 @@ def draw_region_gene_structures(
                 x_end = LEFT_MARGIN + (feat.end - draw_start) / shrink_factor * scale
                 width = x_end - x_start
 
+                # ドメイン色はattributesから取得
+                feat_domain_color = feat.attributes.get('color', domain_color)
+
                 dwg.add(
                     dwg.rect(
                         insert=(x_start, y_pos),
                         size=(width, height_feature),
-                        fill=domain_color,
+                        fill=feat_domain_color,
                         stroke=FEATURE_OUTLINES.get('domain', 'black'),
                         stroke_width=FEATURE_OUTLINE_WIDTHS.get('domain', 1)
                     )
@@ -674,29 +965,74 @@ def draw_region_gene_structures(
                 text_anchor='middle'
             ))
 
-    # === 凡例（右上に1つだけ配置） ===
+    # === 凡例の動的生成 ===
+    # 全遺伝子のfeature typeを収集
+    all_feature_types = set()
+    all_domain_colors = {}
+    has_insertions = False
+    has_snps = False
+    for gene in genes:
+        for f in gene.get_sorted_features():
+            all_feature_types.add(f.feature_type)
+        all_domain_colors.update(getattr(gene, 'domain_color_map', {}))
+        if getattr(gene, "insertions", []):
+            has_insertions = True
+        if getattr(gene, "snps", []):
+            has_snps = True
+
+    # 凡例アイテムを動的に構築
+    legend_items = []
+    if 'CDS' in all_feature_types or 'exon' in all_feature_types:
+        legend_items.append(('CDS', 'Exon/CDS', exon_color))
+    if 'five_prime_UTR' in all_feature_types:
+        legend_items.append(('five_prime_UTR', "5' UTR", utr_color))
+    if 'three_prime_UTR' in all_feature_types:
+        legend_items.append(('three_prime_UTR', "3' UTR", utr_color))
+    if 'intron' in all_feature_types:
+        legend_items.append(('intron', 'Intron', line_color))
+    if 'deletion' in all_feature_types:
+        legend_items.append(('deletion', 'Deletion', None))
+    if has_insertions:
+        legend_items.append(('insertion', 'Insertion', None))
+    if has_snps:
+        legend_items.append(('snp', 'SNP', None))
+    # ドメインは名前ごとに個別表示
+    for domain_name, color in all_domain_colors.items():
+        legend_items.append(('domain', domain_name, color))
+
     legend_x = LEFT_MARGIN + axis_width + 50
     legend_y = 30
     box_size = 12
     spacing = 20
-    legend_items = [
-        ('domain', 'Domain', domain_color),
-        ('CDS', 'Exon/CDS', exon_color),
-        ('five_prime_UTR', "5' UTR", utr_color),
-        ('three_prime_UTR', "3' UTR", utr_color),
-        ('intron', 'Intron', line_color),
-        ('deletion', 'Deletion', None)
-    ]
+
     for i, (feat_key, label_text, color) in enumerate(legend_items):
         y_legend = legend_y + i * spacing
         if feat_key == 'deletion':
-            dwg.add(dwg.rect(
-                insert=(legend_x, y_legend),
-                size=(box_size, box_size),
+            # くの字型
+            y_mid = y_legend + box_size // 2
+            dwg.add(dwg.polyline(
+                points=[(legend_x, y_mid), (legend_x + box_size // 2, y_mid - 6), (legend_x + box_size, y_mid)],
                 fill='none',
-                stroke='red',
-                stroke_dasharray="5,5",
-                stroke_width=2
+                stroke='black',
+                stroke_width=1.5,
+                stroke_dasharray="2,2"
+            ))
+        elif feat_key == 'insertion':
+            # 逆三角形
+            y_mid = y_legend + box_size // 2
+            dwg.add(dwg.polygon(
+                points=[(legend_x, y_mid - 4), (legend_x + box_size, y_mid - 4), (legend_x + box_size // 2, y_mid + 4)],
+                fill='black',
+                stroke='black',
+                stroke_width=1.5
+            ))
+        elif feat_key == 'snp':
+            # 縦線
+            dwg.add(dwg.line(
+                start=(legend_x + box_size // 2, y_legend),
+                end=(legend_x + box_size // 2, y_legend + box_size),
+                stroke='black',
+                stroke_width=1.2
             ))
         elif feat_key == 'intron':
             y_line = y_legend + box_size // 2

--- a/api/index.py
+++ b/api/index.py
@@ -153,6 +153,14 @@ async def generate_gene_structure_svg(request: GeneStructureRequest):
             gene.update_features_with_deletions(deletion_regions_as_tuples)
             print("Applied deletions:", request.deletion_regions)
 
+        # SNPsを追加
+        if request.snps:
+            gene.add_snps(request.snps)
+
+        # Insertionsを追加
+        if request.insertions:
+            gene.add_insertions(request.insertions)
+
         # SVGを生成（DrawSettingsから色を取得）
         draw_settings = request.draw_settings
         svg_content = draw_gene_structure(
@@ -198,6 +206,14 @@ async def generate_multi_gene_structure_svg(request: MultiGeneStructureRequest):
             if request.deletion_regions:
                 deletion_regions_as_tuples = [tuple(r) for r in request.deletion_regions]
                 gene.update_features_with_deletions(deletion_regions_as_tuples)
+
+            # SNPsを追加
+            if request.snps:
+                gene.add_snps(request.snps)
+
+            # Insertionsを追加
+            if request.insertions:
+                gene.add_insertions(request.insertions)
 
             genes.append(gene)
             labels.append(gene_info.transcript_id)

--- a/api/models.py
+++ b/api/models.py
@@ -1,6 +1,9 @@
 from pydantic import BaseModel, field_validator, model_validator
 from typing import Optional, List, Dict, Any
 
+from .config import DOMAIN_COLOR_PALETTE
+from .color_utils import get_domain_color
+
 
 class GeneFeature:
     def __init__(self, seqid, start, end, feature_type, strand, attributes=None):
@@ -18,6 +21,17 @@ class GeneStructure:
         self.seqid = seqid
         self.strand = strand
         self.features = []
+        self.insertions = []
+        self.snps = []
+        self.domain_color_map = {}
+
+    def add_insertions(self, insertion_positions):
+        """Insertion位置のリストを設定"""
+        self.insertions = insertion_positions
+
+    def add_snps(self, snp_positions):
+        """SNP位置のリストを設定"""
+        self.snps = snp_positions
 
     def add_feature(self, feature: GeneFeature):
         self.features.append(feature)
@@ -45,6 +59,12 @@ class GeneStructure:
             end = domain['end']
             name = domain.get('name', '')
             color = domain.get('color', '')
+            # colorが未指定の場合、パレットから自動割り当て
+            if not color:
+                color = get_domain_color(name, self.domain_color_map, DOMAIN_COLOR_PALETTE)
+            else:
+                # 指定された色もdomain_color_mapに記録
+                self.domain_color_map[name] = color
             domain_feature = GeneFeature(
                 self.seqid,
                 start,
@@ -153,6 +173,9 @@ class GeneStructure:
                 g_end = cds.end - offset_start
                 g_start = cds.end - offset_end
 
+            # ドメイン色を取得（まだ割り当てられていなければパレットから自動割り当て）
+            color = get_domain_color(domain_name, self.domain_color_map, DOMAIN_COLOR_PALETTE)
+
             # ドメイン feature を追加
             domain_feature = GeneFeature(
                 seqid=self.seqid,
@@ -160,7 +183,7 @@ class GeneStructure:
                 end=g_end,
                 feature_type='domain',
                 strand=self.strand,
-                attributes={'name': domain_name}
+                attributes={'name': domain_name, 'color': color}
             )
             self.features.append(domain_feature)
 
@@ -223,6 +246,8 @@ class GeneStructureRequest(BaseModel):
     protein_domain_start: Optional[int] = None
     protein_domain_end: Optional[int] = None
     protein_domain_name: Optional[str] = None
+    snps: List[int] = []
+    insertions: List[int] = []
 
     @field_validator('deletion_regions')
     @classmethod
@@ -318,6 +343,8 @@ class MultiGeneStructureRequest(BaseModel):
     protein_domain_start: Optional[int] = None
     protein_domain_end: Optional[int] = None
     protein_domain_name: Optional[str] = None
+    snps: List[int] = []
+    insertions: List[int] = []
 
     @field_validator('gene_structures')
     @classmethod


### PR DESCRIPTION
## Summary
- SNP描画（縦線、exon上下8px貫通）を追加
- Insertion描画（逆三角形、8x6px）を追加
- Deletion描画をくの字型polyline（黒破線2,2）に変更
- Terminal Feature（終端exon/CDSを矢印形状）を追加
- Domain色の動的割り当て（10色パレット）を実装
- 凡例を動的生成（存在するfeatureのみ表示）に変更

## Test plan
- [ ] FastAPIサーバー起動確認
- [ ] SNPありのSVG生成確認
- [ ] Insertionありのsvg生成確認
- [ ] Deletionありのsvg生成確認
- [ ] 複数ドメインありのsvg生成確認
- [ ] CLI版の出力と比較して形状・色が一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)