### PR TITLE
feat: NumberInputをonBlur方式に変更してAPI呼び出しを最適化

### DIFF
--- a/app/components/DelayedNumberInput.tsx
+++ b/app/components/DelayedNumberInput.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { NumberInput, type NumberInputProps } from "@mantine/core";
+import { type KeyboardEvent, useEffect, useState } from "react";
+
+type DelayedNumberInputProps = Omit<NumberInputProps, "onChange"> & {
+  value: number | "" | undefined;
+  onChange: (value: number | "") => void;
+};
+
+/**
+ * onBlur または Enter キー押下時に親へ値を通知する NumberInput ラッパー
+ * 入力中は内部状態のみを更新し、確定時に onChange を呼び出す
+ */
+export function DelayedNumberInput({
+  value,
+  onChange,
+  ...props
+}: DelayedNumberInputProps) {
+  const [localValue, setLocalValue] = useState<number | "" | undefined>(value);
+
+  // 親の value が変更された場合、ローカル状態を同期
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  const handleCommit = () => {
+    // 値が変更されている場合のみ onChange を呼び出す
+    if (localValue !== value) {
+      onChange(localValue === undefined ? "" : localValue);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleCommit();
+      e.currentTarget.blur();
+    }
+  };
+
+  return (
+    <NumberInput
+      {...props}
+      value={localValue}
+      onChange={(val) => setLocalValue(val === "" ? undefined : Number(val))}
+      onBlur={handleCommit}
+      onKeyDown={handleKeyDown}
+    />
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,6 +35,7 @@ import {
 import { useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 
+import { DelayedNumberInput } from "./components/DelayedNumberInput";
 import { GeneSelector } from "./components/GeneSelector";
 import { RegionSelector } from "./components/RegionSelector";
 import SvgViewer from "./components/SvgViewer";
@@ -975,7 +976,7 @@ export default function Home() {
                             gap="xs"
                             align="flex-end"
                           >
-                            <NumberInput
+                            <DelayedNumberInput
                               label={idx === 0 ? "Start" : undefined}
                               placeholder="e.g., 1"
                               value={domain.start}
@@ -988,7 +989,7 @@ export default function Home() {
                               min={1}
                               style={{ flex: 1 }}
                             />
-                            <NumberInput
+                            <DelayedNumberInput
                               label={idx === 0 ? "End" : undefined}
                               placeholder="e.g., 100"
                               value={domain.end}
@@ -1054,7 +1055,7 @@ export default function Home() {
                             key={`deletion-${idx}-${region[0]}-${region[1]}`}
                             gap="xs"
                           >
-                            <NumberInput
+                            <DelayedNumberInput
                               placeholder="e.g., 12"
                               value={region[0]}
                               onChange={(val) => {
@@ -1066,7 +1067,7 @@ export default function Home() {
                               min={1}
                               style={{ flex: 1 }}
                             />
-                            <NumberInput
+                            <DelayedNumberInput
                               placeholder="e.g., 2000"
                               value={region[1]}
                               onChange={(val) => {
@@ -1121,7 +1122,7 @@ export default function Home() {
                             gap="xs"
                             align="flex-end"
                           >
-                            <NumberInput
+                            <DelayedNumberInput
                               label={idx === 0 ? "Position" : undefined}
                               placeholder="e.g., 100"
                               value={ins.position}
@@ -1134,7 +1135,7 @@ export default function Home() {
                               min={1}
                               style={{ flex: 1 }}
                             />
-                            <NumberInput
+                            <DelayedNumberInput
                               label={idx === 0 ? "Length (bp)" : undefined}
                               placeholder="e.g., 50"
                               value={ins.length}
@@ -1186,7 +1187,7 @@ export default function Home() {
                       <Stack gap="xs">
                         {snpPositions.map((pos, idx) => (
                           <Group key={`snp-${idx}-${pos}`} gap="xs">
-                            <NumberInput
+                            <DelayedNumberInput
                               placeholder="e.g., 150"
                               value={pos}
                               onChange={(val) => {


### PR DESCRIPTION
## Summary
- 入力中は内部状態のみを更新し、フォーカスが外れるかEnterキー押下時に親へ値を通知する`DelayedNumberInput`コンポーネントを作成
- Protein Domains、Deletion Regions、Insertions、SNP Positionsの7箇所のNumberInputを置き換え
- これにより「500」と入力する際の中間状態（5→50→500）での不要なAPI呼び出しを防止

## Test plan
- [ ] 開発サーバーを起動してGFFファイルをアップロード
- [ ] Insertionsセクションで「500」と入力し、入力中にNetwork通信が発生しないことを確認
- [ ] フォーカスを外すかEnterキーでリクエストが飛ぶことを確認
- [ ] 他のNumberInput（Protein Domains、Deletion Regions、SNP Positions）も同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)