### PR TITLE
Fix minus strand terminal arrow direction

### DIFF
--- a/api/drawer.py
+++ b/api/drawer.py
@@ -229,9 +229,9 @@ def draw_scale_bar(dwg, x_pos: float, y_pos: float, scale_bar_bp: int,
 # 描画関数
 # =====================
 
-def get_terminal_feature(features):
+def get_terminal_feature(features, strand="+"):
     """
-    右端（最大 end）にある feature を返す。
+    遺伝子の終端にある feature を返す。
     優先順位: three_prime_UTR > CDS > exon
     """
     priority = ['three_prime_UTR', 'CDS', 'exon']
@@ -239,9 +239,41 @@ def get_terminal_feature(features):
     for ftype in priority:
         candidates = [f for f in features if f.feature_type == ftype]
         if candidates:
+            if strand == '-':
+                return min(candidates, key=lambda f: f.start)
             return max(candidates, key=lambda f: f.end)
 
     return None
+
+
+def draw_terminal_feature(dwg, x_start, x_end, y_pos, height_feature, fill_color,
+                          stroke_color, outline_enabled, stroke_width, strand="+"):
+    tip = min(height_feature // 2, abs(x_end - x_start))
+    if strand == '-':
+        points = [
+            (x_end, y_pos),
+            (x_start + tip, y_pos),
+            (x_start, y_pos + height_feature / 2),
+            (x_start + tip, y_pos + height_feature),
+            (x_end, y_pos + height_feature)
+        ]
+    else:
+        points = [
+            (x_start, y_pos),
+            (x_end - tip, y_pos),
+            (x_end, y_pos + height_feature / 2),
+            (x_end - tip, y_pos + height_feature),
+            (x_start, y_pos + height_feature)
+        ]
+
+    dwg.add(
+        dwg.polygon(
+            points=points,
+            fill=fill_color,
+            stroke=stroke_color if outline_enabled else 'none',
+            stroke_width=stroke_width
+        )
+    )
 
 
 def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_factor=30.0,
@@ -258,7 +290,8 @@ def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_
 
     # Calculate true extents including SNPs and Insertions
     actual_min_start, actual_max_end = gene.get_full_extent()
-    terminal_feature = get_terminal_feature(all_features)
+    gene_strand = gene.strand or strand
+    terminal_feature = get_terminal_feature(all_features, gene_strand)
 
     # 描画用にシフト (内部相対座標 1 を基準にする)
     # 相対座標 1 が LEFT_MARGIN に来るように設定したいが、
@@ -374,20 +407,9 @@ def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_
 
             # Terminal Feature は矢印形状
             if feat is terminal_feature:
-                tip = height_feature // 2
-                dwg.add(
-                    dwg.polygon(
-                        points=[
-                            (x_start, y_pos),
-                            (x_end - tip, y_pos),
-                            (x_end, y_pos + height_feature / 2),
-                            (x_end - tip, y_pos + height_feature),
-                            (x_start, y_pos + height_feature)
-                        ],
-                        fill=fill_color,
-                        stroke=stroke_color if outline_enabled else 'none',
-                        stroke_width=stroke_width
-                    )
+                draw_terminal_feature(
+                    dwg, x_start, x_end, y_pos, height_feature, fill_color,
+                    stroke_color, outline_enabled, stroke_width, gene_strand
                 )
             else:
                 dwg.add(
@@ -730,7 +752,7 @@ def draw_multiple_gene_structures(
     for idx, (gene, label) in enumerate(zip(genes, labels)):
         all_features, actual_min_start, actual_max_end = gene_data[idx]
         y_pos = top_margin + idx * (gene_height + gene_spacing)
-        terminal_feature = get_terminal_feature(all_features)
+        terminal_feature = get_terminal_feature(all_features, gene.strand)
 
         # ラベルを描画
         if show_labels:
@@ -797,20 +819,9 @@ def draw_multiple_gene_structures(
 
                 # Terminal Feature は矢印形状
                 if feat is terminal_feature:
-                    tip = height_feature // 2
-                    dwg.add(
-                        dwg.polygon(
-                            points=[
-                                (x_start, y_pos),
-                                (x_end - tip, y_pos),
-                                (x_end, y_pos + height_feature / 2),
-                                (x_end - tip, y_pos + height_feature),
-                                (x_start, y_pos + height_feature)
-                            ],
-                            fill=fill_color,
-                            stroke=stroke_color if outline_enabled else 'none',
-                            stroke_width=stroke_width
-                        )
+                    draw_terminal_feature(
+                        dwg, x_start, x_end, y_pos, height_feature, fill_color,
+                        stroke_color, outline_enabled, stroke_width, gene.strand
                     )
                 else:
                     dwg.add(
@@ -1172,7 +1183,7 @@ def draw_region_gene_structures(
         actual_max_end = gene_info['end']
         all_features = gene.get_sorted_features()
         y_pos = top_margin + track_idx * (track_height + gene_spacing)
-        terminal_feature = get_terminal_feature(all_features)
+        terminal_feature = get_terminal_feature(all_features, gene.strand)
 
         # Draw baseline (intron style) in segments, skipping deletions
         baseline_segments = get_baseline_segments(draw_start, draw_end, getattr(gene, 'deletion_regions', []))
@@ -1235,20 +1246,9 @@ def draw_region_gene_structures(
 
                 # Terminal Feature は矢印形状
                 if feat is terminal_feature:
-                    tip = height_feature // 2
-                    dwg.add(
-                        dwg.polygon(
-                            points=[
-                                (x_start, y_pos),
-                                (x_end - tip, y_pos),
-                                (x_end, y_pos + height_feature / 2),
-                                (x_end - tip, y_pos + height_feature),
-                                (x_start, y_pos + height_feature)
-                            ],
-                            fill=fill_color,
-                            stroke=stroke_color if outline_enabled else 'none',
-                            stroke_width=stroke_width
-                        )
+                    draw_terminal_feature(
+                        dwg, x_start, x_end, y_pos, height_feature, fill_color,
+                        stroke_color, outline_enabled, stroke_width, gene.strand
                     )
                 else:
                     dwg.add(

--- a/api/test_drawer.py
+++ b/api/test_drawer.py
@@ -1,0 +1,52 @@
+import svgwrite
+
+from api.drawer import draw_terminal_feature, get_terminal_feature
+from api.models import GeneFeature
+
+
+def test_get_terminal_feature_uses_rightmost_feature_on_plus_strand():
+    features = [
+        GeneFeature("chr1", 1, 100, "CDS", "+"),
+        GeneFeature("chr1", 300, 500, "CDS", "+"),
+    ]
+
+    terminal = get_terminal_feature(features, "+")
+
+    assert terminal.start == 300
+    assert terminal.end == 500
+
+
+def test_get_terminal_feature_uses_leftmost_feature_on_minus_strand():
+    features = [
+        GeneFeature("chr1", 1, 100, "CDS", "-"),
+        GeneFeature("chr1", 300, 500, "CDS", "-"),
+    ]
+
+    terminal = get_terminal_feature(features, "-")
+
+    assert terminal.start == 1
+    assert terminal.end == 100
+
+
+def test_draw_terminal_feature_points_left_on_minus_strand():
+    dwg = svgwrite.Drawing(size=(200, 80))
+
+    draw_terminal_feature(
+        dwg,
+        x_start=20,
+        x_end=120,
+        y_pos=10,
+        height_feature=15,
+        fill_color="lightblue",
+        stroke_color="black",
+        outline_enabled=True,
+        stroke_width=1,
+        strand="-",
+    )
+
+    svg = dwg.tostring()
+
+    assert "20,17.5" in svg
+    assert "120,10" in svg
+    assert "120,25" in svg
+    assert "120,17.5" not in svg


### PR DESCRIPTION
## Summary
- select the terminal feature by strand so minus-strand genes use the leftmost terminal feature
- draw terminal arrowheads to the left for minus-strand genes across single, multi, and region SVG renderers
- add focused drawer tests for terminal feature selection and minus-strand arrow geometry

## Tests
- venv/bin/python -m pytest api/test_drawer.py api/test_models.py
- npm run review:svg

Note: venv/bin/python -m pytest api still has an existing failure in api/test_deletions.py::test_update_features_with_deletions_all_types unrelated to this change.