### PR TITLE
Fix region mode axis label overlap

### DIFF
--- a/api/drawer.py
+++ b/api/drawer.py
@@ -101,6 +101,25 @@ def get_baseline_segments(actual_min_start: int, actual_max_end: int, deletion_r
         
     return [s for s in segments if s[0] < s[1]]
 
+def get_structural_extent(gene: GeneStructure) -> tuple:
+    """
+    遺伝子本体を構成するフィーチャーだけから開始・終了座標を返す。
+    domain や variant は遺伝子外に置かれることがあるため、ベースラインの範囲には使わない。
+    """
+    structural_types = {'exon', 'CDS', 'five_prime_UTR', 'three_prime_UTR', 'intron'}
+    structural_features = [
+        f for f in gene.features
+        if f.feature_type in structural_types
+    ]
+
+    if not structural_features:
+        return gene.get_full_extent()
+
+    return (
+        min(f.start for f in structural_features),
+        max(f.end for f in structural_features),
+    )
+
 def get_tick_params(range_size: int, shrink_factor: float = 30.0, scale: float = 2.0) -> tuple:
     """
     範囲サイズと物理的なスケールに応じて、重なり合わない適切な目盛り間隔と単位を返す
@@ -126,8 +145,8 @@ def get_tick_params(range_size: int, shrink_factor: float = 30.0, scale: float =
             break
     
     # 範囲に対して目盛りが少なすぎる（3個未満）場合は、一段階細かいステップを検討
-    # ただし、物理的な重なりを避けるため min_bp_step/2 までは許容する
-    if range_size / step < 2.5 and step / 2 >= min_bp_step / 2:
+    # ただし、ラベルの重なりを避けるため最小ピクセル間隔は下回らない
+    if range_size / step < 2.5 and step / 2 >= min_bp_step:
         if step == 10 * magnitude: step = 5 * magnitude
         elif step == 5 * magnitude: step = 2 * magnitude
         elif step == 2 * magnitude: step = 1 * magnitude
@@ -1181,12 +1200,13 @@ def draw_region_gene_structures(
         label = gene_info['label']
         actual_min_start = gene_info['start']
         actual_max_end = gene_info['end']
+        structural_start, structural_end = get_structural_extent(gene)
         all_features = gene.get_sorted_features()
         y_pos = top_margin + track_idx * (track_height + gene_spacing)
         terminal_feature = get_terminal_feature(all_features, gene.strand)
 
         # Draw baseline (intron style) in segments, skipping deletions
-        baseline_segments = get_baseline_segments(draw_start, draw_end, getattr(gene, 'deletion_regions', []))
+        baseline_segments = get_baseline_segments(structural_start, structural_end, getattr(gene, 'deletion_regions', []))
         y_line = y_pos + height_feature // 2
         for seg_start, seg_end in baseline_segments:
             x_base_start = LEFT_MARGIN + (seg_start - draw_start) / shrink_factor * scale

--- a/api/test_drawer.py
+++ b/api/test_drawer.py
@@ -1,52 +1,108 @@
+import unittest
+
 import svgwrite
 
-from api.drawer import draw_terminal_feature, get_terminal_feature
-from api.models import GeneFeature
+from api.drawer import draw_region_gene_structures, draw_terminal_feature, get_terminal_feature, get_tick_params
+from api.models import GeneFeature, GeneStructure
 
 
-def test_get_terminal_feature_uses_rightmost_feature_on_plus_strand():
-    features = [
-        GeneFeature("chr1", 1, 100, "CDS", "+"),
-        GeneFeature("chr1", 300, 500, "CDS", "+"),
-    ]
+class DrawerTest(unittest.TestCase):
+    def test_get_terminal_feature_uses_rightmost_feature_on_plus_strand(self):
+        features = [
+            GeneFeature("chr1", 1, 100, "CDS", "+"),
+            GeneFeature("chr1", 300, 500, "CDS", "+"),
+        ]
 
-    terminal = get_terminal_feature(features, "+")
+        terminal = get_terminal_feature(features, "+")
 
-    assert terminal.start == 300
-    assert terminal.end == 500
+        self.assertEqual(terminal.start, 300)
+        self.assertEqual(terminal.end, 500)
+
+    def test_get_terminal_feature_uses_leftmost_feature_on_minus_strand(self):
+        features = [
+            GeneFeature("chr1", 1, 100, "CDS", "-"),
+            GeneFeature("chr1", 300, 500, "CDS", "-"),
+        ]
+
+        terminal = get_terminal_feature(features, "-")
+
+        self.assertEqual(terminal.start, 1)
+        self.assertEqual(terminal.end, 100)
+
+    def test_draw_terminal_feature_points_left_on_minus_strand(self):
+        dwg = svgwrite.Drawing(size=(200, 80))
+
+        draw_terminal_feature(
+            dwg,
+            x_start=20,
+            x_end=120,
+            y_pos=10,
+            height_feature=15,
+            fill_color="lightblue",
+            stroke_color="black",
+            outline_enabled=True,
+            stroke_width=1,
+            strand="-",
+        )
+
+        svg = dwg.tostring()
+
+        self.assertIn("20,17.5", svg)
+        self.assertIn("120,10", svg)
+        self.assertIn("120,25", svg)
+        self.assertNotIn("120,17.5", svg)
+
+    def test_get_tick_params_does_not_relax_below_minimum_label_spacing(self):
+        tick_interval, unit_label, divisor = get_tick_params(
+            range_size=2400,
+            shrink_factor=30.0,
+            scale=2.0,
+        )
+
+        self.assertEqual(tick_interval, 1000)
+        self.assertEqual(unit_label, "kb")
+        self.assertEqual(divisor, 1000)
+
+    def test_region_baseline_is_limited_to_each_gene_extent(self):
+        left_gene = GeneStructure("region-left", "chr1", "+")
+        left_gene.add_feature(GeneFeature("chr1", 1000, 1079, "five_prime_UTR", "+"))
+        left_gene.add_feature(GeneFeature("chr1", 1080, 1150, "CDS", "+"))
+        left_gene.add_feature(GeneFeature("chr1", 1151, 1499, "intron", "+"))
+        left_gene.add_feature(GeneFeature("chr1", 1500, 1750, "CDS", "+"))
+        left_gene.add_feature(GeneFeature("chr1", 1751, 1900, "three_prime_UTR", "+"))
+
+        right_gene = GeneStructure("region-right", "chr1", "-")
+        right_gene.add_feature(GeneFeature("chr1", 2300, 2449, "five_prime_UTR", "-"))
+        right_gene.add_feature(GeneFeature("chr1", 2450, 2600, "CDS", "-"))
+        right_gene.add_feature(GeneFeature("chr1", 2601, 2899, "intron", "-"))
+        right_gene.add_feature(GeneFeature("chr1", 2900, 3080, "CDS", "-"))
+        right_gene.add_feature(GeneFeature("chr1", 3081, 3200, "three_prime_UTR", "-"))
+
+        svg = draw_region_gene_structures(
+            genes=[left_gene, right_gene],
+            labels=["region-left", "region-right"],
+            region_start=900,
+            region_end=3300,
+            line_color="#222222",
+        )
+
+        self.assertIn(
+            'stroke="#222222" stroke-width="1" x1="56.666666666666664" x2="116.66666666666667" y1="57" y2="57"',
+            svg,
+        )
+        self.assertIn(
+            'stroke="#222222" stroke-width="1" x1="143.33333333333331" x2="203.33333333333334" y1="147" y2="147"',
+            svg,
+        )
+        self.assertNotIn(
+            'stroke="#222222" stroke-width="1" x1="50.0" x2="210.0" y1="57" y2="57"',
+            svg,
+        )
+        self.assertNotIn(
+            'stroke="#222222" stroke-width="1" x1="50.0" x2="210.0" y1="147" y2="147"',
+            svg,
+        )
 
 
-def test_get_terminal_feature_uses_leftmost_feature_on_minus_strand():
-    features = [
-        GeneFeature("chr1", 1, 100, "CDS", "-"),
-        GeneFeature("chr1", 300, 500, "CDS", "-"),
-    ]
-
-    terminal = get_terminal_feature(features, "-")
-
-    assert terminal.start == 1
-    assert terminal.end == 100
-
-
-def test_draw_terminal_feature_points_left_on_minus_strand():
-    dwg = svgwrite.Drawing(size=(200, 80))
-
-    draw_terminal_feature(
-        dwg,
-        x_start=20,
-        x_end=120,
-        y_pos=10,
-        height_feature=15,
-        fill_color="lightblue",
-        stroke_color="black",
-        outline_enabled=True,
-        stroke_width=1,
-        strand="-",
-    )
-
-    svg = dwg.tostring()
-
-    assert "20,17.5" in svg
-    assert "120,10" in svg
-    assert "120,25" in svg
-    assert "120,17.5" not in svg
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prevent tick interval relaxation from going below the minimum label spacing
- limit region baselines to each gene's structural extent
- add drawer tests for tick spacing and region baselines

## Tests
- uv run --with-requirements requirements.txt python -m unittest api.test_drawer
- uv run --with-requirements requirements.txt python scripts/generate_svg_visual_review.py