### PR TITLE
Fix non-region strand arrow orientation

### DIFF
--- a/api/drawer.py
+++ b/api/drawer.py
@@ -309,8 +309,11 @@ def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_
 
     # Calculate true extents including SNPs and Insertions
     actual_min_start, actual_max_end = gene.get_full_extent()
-    gene_strand = gene.strand or strand
-    terminal_feature = get_terminal_feature(all_features, gene_strand)
+    # region mode はゲノム座標上の strand 方向を維持する。
+    # それ以外では to_relative() で 5' -> 3' が左から右へ揃うため、
+    # 3' 側 terminal feature を右向き矢印として描画する。
+    arrow_strand = "+"
+    terminal_feature = get_terminal_feature(all_features, arrow_strand)
 
     # 描画用にシフト (内部相対座標 1 を基準にする)
     # 相対座標 1 が LEFT_MARGIN に来るように設定したいが、
@@ -428,7 +431,7 @@ def draw_gene_structure(gene: GeneStructure, scale=2, extra_padding=100, shrink_
             if feat is terminal_feature:
                 draw_terminal_feature(
                     dwg, x_start, x_end, y_pos, height_feature, fill_color,
-                    stroke_color, outline_enabled, stroke_width, gene_strand
+                    stroke_color, outline_enabled, stroke_width, arrow_strand
                 )
             else:
                 dwg.add(
@@ -771,7 +774,11 @@ def draw_multiple_gene_structures(
     for idx, (gene, label) in enumerate(zip(genes, labels)):
         all_features, actual_min_start, actual_max_end = gene_data[idx]
         y_pos = top_margin + idx * (gene_height + gene_spacing)
-        terminal_feature = get_terminal_feature(all_features, gene.strand)
+        # region mode はゲノム座標上の strand 方向を維持する。
+        # それ以外では to_relative() で 5' -> 3' が左から右へ揃うため、
+        # 3' 側 terminal feature を右向き矢印として描画する。
+        arrow_strand = "+"
+        terminal_feature = get_terminal_feature(all_features, arrow_strand)
 
         # ラベルを描画
         if show_labels:
@@ -840,7 +847,7 @@ def draw_multiple_gene_structures(
                 if feat is terminal_feature:
                     draw_terminal_feature(
                         dwg, x_start, x_end, y_pos, height_feature, fill_color,
-                        stroke_color, outline_enabled, stroke_width, gene.strand
+                        stroke_color, outline_enabled, stroke_width, arrow_strand
                     )
                 else:
                     dwg.add(

--- a/api/models.py
+++ b/api/models.py
@@ -33,6 +33,7 @@ class GeneStructure:
         self.snps: List[Snp] = []
         self.deletion_regions: List[Deletion] = []
         self.domain_color_map = {}
+        self.is_relative = False
 
     def add_insertions(self, insertions: List[Insertion]):
         """Insertionオブジェクトのリストを設定"""
@@ -256,6 +257,9 @@ class GeneStructure:
             ]
 
     def to_relative(self):
+        if self.is_relative:
+            return 1
+
         # 基準（1番）を決定するためのフィーチャーを選択
         # ユーザー要望により、Exon または CDS の開始位置を基準とする
         anchor_targets = [f for f in self.features if f.feature_type in ('exon', 'CDS')]
@@ -347,6 +351,7 @@ class GeneStructure:
                         d['start'] = s_orig - anchor + 1
                         d['end'] = e_orig - anchor + 1
 
+        self.is_relative = True
         return 1
 
     def add_domain_from_protein_coords(self, start_aa: int, end_aa: int, domain_name: str):

--- a/api/test_drawer.py
+++ b/api/test_drawer.py
@@ -1,12 +1,39 @@
 import unittest
+import re
 
 import svgwrite
 
-from api.drawer import draw_region_gene_structures, draw_terminal_feature, get_terminal_feature, get_tick_params
+from api.drawer import (
+    draw_gene_structure,
+    draw_multiple_gene_structures,
+    draw_region_gene_structures,
+    draw_terminal_feature,
+    get_terminal_feature,
+    get_tick_params,
+)
 from api.models import GeneFeature, GeneStructure
 
 
 class DrawerTest(unittest.TestCase):
+    def _minus_gene_with_two_cds(self):
+        gene = GeneStructure("minus", "chr1", "-")
+        gene.add_feature(GeneFeature("chr1", 100, 600, "CDS", "-"))
+        gene.add_feature(GeneFeature("chr1", 1000, 1500, "CDS", "-"))
+        return gene
+
+    def _first_polygon_points(self, svg):
+        match = re.search(r'<polygon\b[^>]*\bpoints="([^"]+)"', svg)
+        self.assertIsNotNone(match)
+        return [
+            tuple(float(coord) for coord in point.split(","))
+            for point in match.group(1).split()
+        ]
+
+    def _first_rect_x(self, svg):
+        match = re.search(r'<rect\b[^>]*\bx="([^"]+)"', svg)
+        self.assertIsNotNone(match)
+        return float(match.group(1))
+
     def test_get_terminal_feature_uses_rightmost_feature_on_plus_strand(self):
         features = [
             GeneFeature("chr1", 1, 100, "CDS", "+"),
@@ -51,6 +78,52 @@ class DrawerTest(unittest.TestCase):
         self.assertIn("120,10", svg)
         self.assertIn("120,25", svg)
         self.assertNotIn("120,17.5", svg)
+
+    def test_single_gene_minus_strand_draws_three_prime_terminal_arrow_on_right(self):
+        svg = draw_gene_structure(self._minus_gene_with_two_cds())
+
+        points = self._first_polygon_points(svg)
+        tip_x = points[2][0]
+
+        self.assertEqual(tip_x, max(x for x, _ in points))
+        self.assertGreater(min(x for x, _ in points), self._first_rect_x(svg))
+
+    def test_single_gene_pre_relative_minus_strand_still_draws_three_prime_arrow_on_right(self):
+        gene = self._minus_gene_with_two_cds()
+        gene.to_relative()
+
+        svg = draw_gene_structure(gene)
+
+        points = self._first_polygon_points(svg)
+        tip_x = points[2][0]
+
+        self.assertEqual(tip_x, max(x for x, _ in points))
+        self.assertGreater(min(x for x, _ in points), self._first_rect_x(svg))
+
+    def test_multiple_gene_minus_strand_draws_three_prime_terminal_arrow_on_right(self):
+        svg = draw_multiple_gene_structures(
+            [self._minus_gene_with_two_cds()],
+            ["minus"],
+        )
+
+        points = self._first_polygon_points(svg)
+        tip_x = points[2][0]
+
+        self.assertEqual(tip_x, max(x for x, _ in points))
+        self.assertGreater(min(x for x, _ in points), self._first_rect_x(svg))
+
+    def test_region_mode_minus_strand_keeps_left_pointing_arrow(self):
+        svg = draw_region_gene_structures(
+            genes=[self._minus_gene_with_two_cds()],
+            labels=["minus"],
+            region_start=1,
+            region_end=1600,
+        )
+
+        points = self._first_polygon_points(svg)
+        tip_x = points[2][0]
+
+        self.assertEqual(tip_x, min(x for x, _ in points))
 
     def test_get_tick_params_does_not_relax_below_minimum_label_spacing(self):
         tick_interval, unit_label, divisor = get_tick_params(


### PR DESCRIPTION
## Summary
- Keep non-region gene rendering normalized left-to-right from 5' to 3'
- Draw the 3' terminal feature as a right-pointing arrow outside region mode
- Prevent repeated relative-coordinate conversion from reversing minus-strand genes twice

## Tests
- venv/bin/python -m unittest discover api
- venv/bin/python scripts/generate_svg_visual_review.py